### PR TITLE
Update 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Deathrun Neue
+# Deathrun Neu
 I was fed up with the lack of good public Deathrun plugins out there, so I went ahead and made my own.
 
 Inspired by the plugins I played many years back that were never made accessible to the public, this plugin aims to keep player restrictions as little as possible while not ruining the gameplay.

--- a/addons/sourcemod/configs/deathrun/weapons.cfg
+++ b/addons/sourcemod/configs/deathrun/weapons.cfg
@@ -39,7 +39,15 @@
 	// Scout Secondary
 	"46;1145"	// Bonk! Atomic Punch
 	{
-		"block_attack"	"1"
+		"attributes"
+		{
+			"attribute"
+			{
+				"name"	"item_meter_charge_rate"
+				"value"	"-1.0"
+				"mode"	"set"
+			}
+		}
 	}
 	"449"	// Winger
 	{
@@ -52,11 +60,6 @@
 				"mode"	"set"
 			}
 		}
-	}
-	"812;833"	// Flying Guillotine
-	{
-		"block_attack"	"1"	// Can go through thin walls
-		"block_attack2"	"1"
 	}
 	
 	// Scout Melee
@@ -112,8 +115,15 @@
 	}
 	"1179"	// Thermal Thruster
 	{
-		"block_attack"	"1"
-		"block_attack2"	"1"
+		"attributes"
+		{
+			"attribute"
+			{
+				"name"	"item_meter_charge_rate"
+				"value"	"-1.0"
+				"mode"	"set"
+			}
+		}
 	}
 	
 	// Demoman Primary
@@ -192,12 +202,6 @@
 				"mode"	"remove"
 			}
 		}
-	}
-	
-	// Engineer Secondary
-	"528"	// Short Circuit
-	{
-		"block_attack2"	"1"	// Can go through thin walls
 	}
 	
 	// Medic Primary

--- a/addons/sourcemod/configs/deathrun/weapons.cfg
+++ b/addons/sourcemod/configs/deathrun/weapons.cfg
@@ -39,15 +39,7 @@
 	// Scout Secondary
 	"46;1145"	// Bonk! Atomic Punch
 	{
-		"attributes"
-		{
-			"attribute"
-			{
-				"name"	"item_meter_charge_rate"
-				"value"	"-1.0"
-				"mode"	"set"
-			}
-		}
+		"block_attack"	"1"
 	}
 	"449"	// Winger
 	{

--- a/addons/sourcemod/gamedata/deathrun.txt
+++ b/addons/sourcemod/gamedata/deathrun.txt
@@ -2,6 +2,14 @@
 {
 	"tf"
 	{
+		"Offsets"
+		{
+			"CTeamplayRoundBasedRules::SetWinningTeam"
+			{
+				"linux"		"161"
+				"windows"	"160"
+			}
+		}
 		"Signatures"
 		{
 			"CTFPlayer::GetEquippedWearableForLoadoutSlot"
@@ -19,6 +27,40 @@
 		}
 		"Functions"
 		{
+			"CTeamplayRoundBasedRules::SetWinningTeam"
+			{
+				"offset"	"CTeamplayRoundBasedRules::SetWinningTeam"
+				"hooktype"	"gamerules"
+				"return"	"void"
+				"this"		"ignore"
+				"arguments"
+				{
+					"team"
+					{
+						"type"	"int"
+					}
+					"iWinReason"
+					{
+						"type"	"int"
+					}
+					"bForceMapReset"
+					{
+						"type"	"bool"
+					}
+					"bSwitchTeams"
+					{
+						"type"	"bool"
+					}
+					"bDontAddScore"
+					{
+						"type"	"bool"
+					}
+					"bFinal"
+					{
+						"type"	"bool"
+					}
+				}
+			}
 			"CTFPlayer::TeamFortress_CalculateMaxSpeed"
 			{
 				"signature"	"CTFPlayer::TeamFortress_CalculateMaxSpeed"

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -22,8 +22,6 @@
 #define TF_MAXPLAYERS		33
 #define INTEGER_MAX_VALUE	0x7FFFFFFF
 
-#define WEAPON_CONFIG_FILE		"configs/deathrun/weapons.cfg"
-
 // m_lifeState values
 #define LIFE_ALIVE				0 // alive
 #define LIFE_DYING				1 // playing death animation or still falling off of a ledge waiting to hit ground
@@ -95,6 +93,7 @@ char g_OwnerEntityList[][] =  {
 ConVar dr_queue_points;
 ConVar dr_allow_thirdperson;
 ConVar dr_chattips_interval;
+ConVar dr_runner_glow;
 
 int g_CurrentActivator = -1;
 

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -57,6 +57,28 @@ enum
 	WeaponSlot_Misc2
 };
 
+// TF2 win reasons (from teamplayroundbased_gamerules.h)
+enum
+{
+	WINREASON_NONE = 0, 
+	WINREASON_ALL_POINTS_CAPTURED, 
+	WINREASON_OPPONENTS_DEAD, 
+	WINREASON_FLAG_CAPTURE_LIMIT, 
+	WINREASON_DEFEND_UNTIL_TIME_LIMIT, 
+	WINREASON_STALEMATE, 
+	WINREASON_TIMELIMIT, 
+	WINREASON_WINLIMIT, 
+	WINREASON_WINDIFFLIMIT, 
+	WINREASON_RD_REACTOR_CAPTURED, 
+	WINREASON_RD_CORES_COLLECTED, 
+	WINREASON_RD_REACTOR_RETURNED, 
+	WINREASON_PD_POINTS, 
+	WINREASON_SCORED, 
+	WINREASON_STOPWATCH_WATCHING_ROUNDS, 
+	WINREASON_STOPWATCH_WATCHING_FINAL_ROUND, 
+	WINREASON_STOPWATCH_PLAYING_ROUNDS
+};
+
 char g_PreferenceNames[][] =  {
 	"Preference_DontBeActivator",
 	"Preference_HideChatTips"
@@ -72,12 +94,9 @@ char g_OwnerEntityList[][] =  {
 
 ConVar dr_queue_points;
 ConVar dr_allow_thirdperson;
-ConVar dr_round_time;
 ConVar dr_chattips_interval;
 
 int g_CurrentActivator = -1;
-
-Handle g_RoundTimer;
 
 #include "deathrun/player.sp"
 
@@ -114,7 +133,7 @@ public void OnPluginStart()
 	Config_Init();
 	ConVars_Init();
 	Events_Init();
-	Timer_Init();
+	Timers_Init();
 	
 	GameData gamedata = new GameData("deathrun");
 	if (gamedata == null)
@@ -122,6 +141,8 @@ public void OnPluginStart()
 	
 	DHooks_Init(gamedata);
 	SDKCalls_Init(gamedata);
+	
+	DHooks_HookGamerules();
 	
 	ConVars_Enable();
 	

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -17,7 +17,7 @@
 #define PLUGIN_VERSION		"v1.1"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
-#define GAMESOUND_EXPLOSION	"MVM.BombExplode"
+#define GAMESOUND_EXPLOSION	"MVM.BombExplodes"
 
 #define TF_MAXPLAYERS		33
 #define INTEGER_MAX_VALUE	0x7FFFFFFF

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -170,7 +170,6 @@ void RequestFrameCallback_VerifyTeam(int userid)
 	int client = GetClientOfUserId(userid);
 	if (IsValidClient(client) && IsClientInGame(client))
 	{
-		
 		TFTeam team = TF2_GetClientTeam(client);
 		if (team <= TFTeam_Spectator)return;
 		

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -11,7 +11,7 @@
 
 #pragma newdecls required
 
-#define PLUGIN_NAME			"Deathrun Neue"
+#define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
 #define PLUGIN_DESCRIPTION	"Team Fortress 2 Deathrun"
 #define PLUGIN_VERSION		"v1.1"
@@ -80,7 +80,7 @@ enum
 };
 
 char g_PreferenceNames[][] =  {
-	"Preference_DontBeActivator",
+	"Preference_DontBeActivator", 
 	"Preference_HideChatTips"
 };
 
@@ -89,7 +89,7 @@ char g_OwnerEntityList[][] =  {
 	"projectile_energy_ball", 
 	"weapon", 
 	"wearable", 
-	"prop_physics"	//Conch
+	"prop_physics" //Conch
 };
 
 ConVar dr_queue_points;
@@ -115,10 +115,10 @@ int g_CurrentActivator = -1;
 #include "deathrun/timers.sp"
 
 public Plugin pluginInfo =  {
-	name = PLUGIN_NAME,
-	author = PLUGIN_AUTHOR,
-	description = PLUGIN_DESCRIPTION,
-	version = PLUGIN_VERSION,
+	name = PLUGIN_NAME, 
+	author = PLUGIN_AUTHOR, 
+	description = PLUGIN_DESCRIPTION, 
+	version = PLUGIN_VERSION, 
 	url = PLUGIN_URL
 };
 
@@ -126,6 +126,9 @@ public void OnPluginStart()
 {
 	LoadTranslations("common.phrases.txt");
 	LoadTranslations("deathrun.phrases.txt");
+	
+	CAddColor("primary", 0xF26C4F);
+	CAddColor("secondary", 0x3A89C9);
 	
 	Commands_Init();
 	Console_Init();
@@ -153,7 +156,7 @@ public void OnPluginStart()
 	{
 		if (IsClientInGame(client))
 			OnClientPutInServer(client);
-			
+		
 		if (AreClientCookiesCached(client))
 			OnClientCookiesCached(client);
 	}
@@ -196,7 +199,7 @@ void RequestFrameCallback_VerifyTeam(int userid)
 		
 		if (DRPlayer(client).IsActivator())
 		{
-			if (team == TFTeam_Red) //Check if player is in the runner team, if so put them back to the activator team
+			if (team == TFTeam_Runners) //Check if player is in the runner team, if so put them back to the activator team
 			{
 				TF2_ChangeClientTeam(client, TFTeam_Activator);
 				TF2_RespawnPlayer(client);
@@ -204,9 +207,9 @@ void RequestFrameCallback_VerifyTeam(int userid)
 		}
 		else
 		{
-			if (team == TFTeam_Blue) //Check if player is in the activator team, if so put them back to the runner team
+			if (team == TFTeam_Activator) //Check if player is in the activator team, if so put them back to the runner team
 			{
-				TF2_ChangeClientTeam(client, TFTeam_Red);
+				TF2_ChangeClientTeam(client, TFTeam_Runners);
 				TF2_RespawnPlayer(client);
 			}
 		}
@@ -269,11 +272,4 @@ public void OnClientPutInServer(int client)
 public void OnClientDisconnect(int client)
 {
 	DRPlayer(client).Reset();
-}
-
-stock void PrintLocalizedMessage(int client, const char[] format, any ...)
-{
-	char buffer[256];
-	VFormat(buffer, sizeof(buffer), format, 3);
-	CPrintToChat(client, "[{orange}DR{default}] %s", buffer);
 }

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -14,7 +14,7 @@
 #define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
 #define PLUGIN_DESCRIPTION	"Team Fortress 2 Deathrun"
-#define PLUGIN_VERSION		"v1.1"
+#define PLUGIN_VERSION		"v1.2"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
 #define GAMESOUND_EXPLOSION	"MVM.BombExplodes"

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -17,7 +17,7 @@
 #define PLUGIN_VERSION		"v1.1"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
-#define TIMER_EXPLOSION_SOUND	"items/cart_explode.wav"
+#define GAMESOUND_EXPLOSION	"MVM.BombExplode"
 
 #define TF_MAXPLAYERS		33
 #define INTEGER_MAX_VALUE	0x7FFFFFFF
@@ -140,7 +140,7 @@ public void OnPluginStart()
 
 public void OnMapStart()
 {
-	PrecacheSound(TIMER_EXPLOSION_SOUND);
+	PrecacheScriptSound(GAMESOUND_EXPLOSION);
 }
 
 public void OnConfigsExecuted()

--- a/addons/sourcemod/scripting/deathrun/commands.sp
+++ b/addons/sourcemod/scripting/deathrun/commands.sp
@@ -81,7 +81,7 @@ public Action Command_Thirdperson(int client, int args)
 	
 	if (!dr_allow_thirdperson.BoolValue)
 	{
-		PrintLocalizedMessage(client, "%t", "Command_Disabled");
+		PrintMessage(client, "%t", "Command_Disabled");
 		return Plugin_Handled;
 	}
 	
@@ -113,7 +113,7 @@ public Action Command_Firstperson(int client, int args)
 	
 	if (!dr_allow_thirdperson.BoolValue)
 	{
-		PrintLocalizedMessage(client, "%t", "Command_Disabled");
+		PrintMessage(client, "%t", "Command_Disabled");
 		return Plugin_Handled;
 	}
 	

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -1,3 +1,5 @@
+#define WEAPON_CONFIG_FILE		"configs/deathrun/weapons.cfg"
+
 enum AttributeModMode
 {
 	ModMode_Set,		/*< Sets the attribute, adding it if it doesn't exist */

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -13,7 +13,6 @@ void ConVars_Init()
 	CreateConVar("dr_version", PLUGIN_VERSION, "Plugin version");
 	dr_queue_points = CreateConVar("dr_queue_points", "15", "Amount of queue points awarded to clients at the end of each round.");
 	dr_allow_thirdperson = CreateConVar("dr_allow_thirdperson", "1", "Whether thirdperson mode may be toggled by clients. Set to 0 if you use other thirdperson plugins that may conflict.");
-	dr_round_time = CreateConVar("dr_round_time", "0", "Amount of time in seconds runners have to complete the map. Set to 0 to disable the round timer.");
 	dr_chattips_interval = CreateConVar("dr_chattips_interval", "240", "How often in seconds chat tips should be shown to clients. Set to 0 to disable chat tips.");
 	
 	HookConVarChange(dr_allow_thirdperson, OnAllowThirdpersonChanged);

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -73,7 +73,7 @@ void OnAllowThirdpersonChanged(ConVar convar, const char[] oldValue, const char[
 				DRPlayer(client).InThirdPerson = false;
 				SetVariantInt(0);
 				AcceptEntityInput(client, "SetForcedTauntCam");
-				PrintLocalizedMessage(client, "%T", "Thirdperson_ForceDisable", LANG_SERVER);
+				PrintMessage(client, "%T", "Thirdperson_ForceDisable", LANG_SERVER);
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -14,8 +14,10 @@ void ConVars_Init()
 	dr_queue_points = CreateConVar("dr_queue_points", "15", "Amount of queue points awarded to clients at the end of each round.");
 	dr_allow_thirdperson = CreateConVar("dr_allow_thirdperson", "1", "Whether thirdperson mode may be toggled by clients. Set to 0 if you use other thirdperson plugins that may conflict.");
 	dr_chattips_interval = CreateConVar("dr_chattips_interval", "240", "How often in seconds chat tips should be shown to clients. Set to 0 to disable chat tips.");
+	dr_runner_glow = CreateConVar("dr_runner_glow", "0", "Whether runners should have an outline.");
 	
 	HookConVarChange(dr_allow_thirdperson, OnAllowThirdpersonChanged);
+	HookConVarChange(dr_runner_glow, OnRunnerGlowChanged);
 	
 	ConVars = new ArrayList(sizeof(ConVarInfo));
 	
@@ -76,6 +78,15 @@ void OnAllowThirdpersonChanged(ConVar convar, const char[] oldValue, const char[
 				PrintMessage(client, "%T", "Thirdperson_ForceDisable", LANG_SERVER);
 			}
 		}
+	}
+}
+
+void OnRunnerGlowChanged(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (IsClientInGame(client) && TF2_GetClientTeam(client) == TFTeam_Runners)
+			SetEntProp(client, Prop_Send, "m_bGlowEnabled", StringToInt(newValue));
 	}
 }
 

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -110,8 +110,6 @@ public Action Event_TeamplayRoundWin(Event event, const char[] name, bool dontBr
 			}
 		}
 	}
-	
-	g_RoundTimer = null;	//Block the big boom
 }
 
 public Action Event_ArenaRoundStart(Event event, const char[] name, bool dontBroadcast)
@@ -160,8 +158,6 @@ public Action Event_ArenaRoundStart(Event event, const char[] name, bool dontBro
 			}
 		}
 	}
-	
-	Timer_OnRoundStart();
 }
 
 public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadcast)

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -58,14 +58,14 @@ public Action Event_TeamplayRoundStart(Event event, const char[] name, bool dont
 				{
 					//Once we found someone who is in red or blue, swap their team
 					TFTeam team = TF2_GetClientTeam(client);
-					if (team == TFTeam_Red)
+					if (team == TFTeam_Runners)
 					{
-						TF2_ChangeClientTeamAlive(client, TFTeam_Blue);
+						TF2_ChangeClientTeamAlive(client, TFTeam_Activator);
 						return;
 					}
-					else if (team == TFTeam_Blue)
+					else if (team == TFTeam_Activator)
 					{
-						TF2_ChangeClientTeamAlive(client, TFTeam_Red);
+						TF2_ChangeClientTeamAlive(client, TFTeam_Runners);
 						return;
 					}
 				}
@@ -80,7 +80,7 @@ public Action Event_TeamplayRoundStart(Event event, const char[] name, bool dont
 	{
 		//Put every player in the same team and pick the activator later
 		if (IsClientInGame(client) && TF2_GetClientTeam(client) > TFTeam_Spectator)
-			TF2_ChangeClientTeamAlive(client, TFTeam_Red);
+			TF2_ChangeClientTeamAlive(client, TFTeam_Runners);
 	}
 	
 	Queue_SetNextActivator();
@@ -95,10 +95,10 @@ public Action Event_TeamplayRoundWin(Event event, const char[] name, bool dontBr
 		DRPlayer player = DRPlayer(client);
 		if (IsClientInGame(client))
 		{ 
-			if (team == TFTeam_Blue)
-				PrintLocalizedMessage(client, "%t", "RoundWin_Activator");
-			else if (team == TFTeam_Red)
-				PrintLocalizedMessage(client, "%t", "RoundWin_Runners");
+			if (team == TFTeam_Activator)
+				PrintMessage(client, "%t", "RoundWin_Activator");
+			else if (team == TFTeam_Runners)
+				PrintMessage(client, "%t", "RoundWin_Runners");
 			
 			if (player.IsActivator())
 			{
@@ -140,7 +140,7 @@ public Action Event_ArenaRoundStart(Event event, const char[] name, bool dontBro
 				SetHudTextParams(-1.0, 0.375, 10.0, 255, 255, 0, 255);
 				ShowHudText(client, -1, PLUGIN_URL);
 				
-				PrintLocalizedMessage(client, "%t", "RoundStart_NewActivator", activatorName);
+				PrintMessage(client, "%t", "RoundStart_NewActivator", activatorName);
 			}
 		}
 		

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -127,18 +127,15 @@ public Action Event_ArenaRoundStart(Event event, const char[] name, bool dontBro
 			{
 				if (DRPlayer(client).IsActivator())
 				{
-					SetHudTextParams(-1.0, 0.25, 10.0, 0, 255, 255, 255);
+					SetHudTextParams(-1.0, 0.25, 10.0, 82, 122, 136, 255);
 					ShowHudText(client, -1, "%t", "RoundStart_NewActivator_Activator");
 				}
 				else
 				{
-					SetHudTextParams(-1.0, 0.25, 10.0, 0, 255, 255, 255);
+					SetHudTextParams(-1.0, 0.25, 10.0, 162, 86, 73, 255);
 					ShowHudText(client, -1, "%t", "RoundStart_NewActivator_Runners", activatorName);
 					SetEntProp(client, Prop_Send, "m_bGlowEnabled", 1);
 				}
-				
-				SetHudTextParams(-1.0, 0.375, 10.0, 255, 255, 0, 255);
-				ShowHudText(client, -1, PLUGIN_URL);
 				
 				PrintMessage(client, "%t", "RoundStart_NewActivator", activatorName);
 			}
@@ -153,7 +150,7 @@ public Action Event_ArenaRoundStart(Event event, const char[] name, bool dontBro
 		{
 			if (IsClientInGame(client))
 			{
-				SetHudTextParams(-1.0, 0.25, FindConVar("mp_bonusroundtime").FloatValue, 0, 255, 255, 255);
+				SetHudTextParams(-1.0, 0.25, FindConVar("mp_bonusroundtime").FloatValue, 204, 204, 204, 255);
 				ShowHudText(client, -1, "%t", "RoundStart_Activator_Disconnected");
 			}
 		}

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -134,7 +134,7 @@ public Action Event_ArenaRoundStart(Event event, const char[] name, bool dontBro
 				{
 					SetHudTextParams(-1.0, 0.25, 10.0, 162, 86, 73, 255);
 					ShowHudText(client, -1, "%t", "RoundStart_NewActivator_Runners", activatorName);
-					SetEntProp(client, Prop_Send, "m_bGlowEnabled", 1);
+					SetEntProp(client, Prop_Send, "m_bGlowEnabled", dr_runner_glow.BoolValue);
 				}
 				
 				PrintMessage(client, "%t", "RoundStart_NewActivator", activatorName);

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -128,12 +128,12 @@ public Action Event_ArenaRoundStart(Event event, const char[] name, bool dontBro
 				if (DRPlayer(client).IsActivator())
 				{
 					SetHudTextParams(-1.0, 0.25, 10.0, 82, 122, 136, 255);
-					ShowHudText(client, -1, "%t", "RoundStart_NewActivator_Activator");
+					ShowHudText(client, 5, "%t", "RoundStart_NewActivator_Activator");
 				}
 				else
 				{
 					SetHudTextParams(-1.0, 0.25, 10.0, 162, 86, 73, 255);
-					ShowHudText(client, -1, "%t", "RoundStart_NewActivator_Runners", activatorName);
+					ShowHudText(client, 5, "%t", "RoundStart_NewActivator_Runners", activatorName);
 					SetEntProp(client, Prop_Send, "m_bGlowEnabled", dr_runner_glow.BoolValue);
 				}
 				
@@ -151,7 +151,7 @@ public Action Event_ArenaRoundStart(Event event, const char[] name, bool dontBro
 			if (IsClientInGame(client))
 			{
 				SetHudTextParams(-1.0, 0.25, FindConVar("mp_bonusroundtime").FloatValue, 204, 204, 204, 255);
-				ShowHudText(client, -1, "%t", "RoundStart_Activator_Disconnected");
+				ShowHudText(client, 5, "%t", "RoundStart_Activator_Disconnected");
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/deathrun/menus.sp
+++ b/addons/sourcemod/scripting/deathrun/menus.sp
@@ -155,9 +155,9 @@ int Menus_HandlePreferencesMenu(Menu menu, MenuAction action, int param1, int pa
 			Format(preferenceName, sizeof(preferenceName), "%T", g_PreferenceNames[i], param1);
 			
 			if (player.HasPreference(preference))
-				PrintLocalizedMessage(param1, "%t", "Preferences_Enabled", preferenceName);
+				PrintMessage(param1, "%t", "Preferences_Enabled", preferenceName);
 			else
-				PrintLocalizedMessage(param1, "%t", "Preferences_Disabled", preferenceName);
+				PrintMessage(param1, "%t", "Preferences_Disabled", preferenceName);
 			
 			Menus_DisplayPreferencesMenu(param1);
 		}

--- a/addons/sourcemod/scripting/deathrun/queue.sp
+++ b/addons/sourcemod/scripting/deathrun/queue.sp
@@ -46,7 +46,7 @@ void Queue_SetNextActivator()
 		}
 		
 		activator = clients[GetRandomInt(0, numClients - 1)];
-		PrintLocalizedMessage(activator, "%t", "Queue_ChosenAsRandomActivator");
+		PrintMessage(activator, "%t", "Queue_ChosenAsRandomActivator");
 	}
 	
 	g_CurrentActivator = activator;
@@ -79,19 +79,19 @@ void Queue_AddPoints(int client, int points)
 	
 	if (player.QueuePoints == -1)
 	{
-		PrintLocalizedMessage(client, "%t", "Queue_NoPointsAwarded_Error");
+		PrintMessage(client, "%t", "Queue_NoPointsAwarded_Error");
 		return;
 	}
 	else if (DRPlayer(client).HasPreference(Preference_DontBeActivator))
 	{
-		PrintLocalizedMessage(client, "%t", "Queue_NoPointsAwarded_Preferences");
+		PrintMessage(client, "%t", "Queue_NoPointsAwarded_Preferences");
 		return;
 	}
 	
 	player.QueuePoints += points;
 	Cookies_SaveQueue(client, player.QueuePoints);
 	
-	PrintLocalizedMessage(client, "%t", "Queue_PointsAwarded", dr_queue_points.IntValue, player.QueuePoints);
+	PrintMessage(client, "%t", "Queue_PointsAwarded", dr_queue_points.IntValue, player.QueuePoints);
 }
 
 void Queue_SetPoints(int client, int points)

--- a/addons/sourcemod/scripting/deathrun/queue.sp
+++ b/addons/sourcemod/scripting/deathrun/queue.sp
@@ -26,8 +26,6 @@ int Queue_GetPlayerInQueuePos(int pos)
 
 void Queue_SetNextActivator()
 {
-	//Note: We may fail to f
-	
 	int activator = Queue_GetPlayerInQueuePos(1);
 	if (IsValidClient(activator)) 
 	{

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -1,7 +1,6 @@
 void SDKHooks_OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_SetTransmit, SDKHookCB_ClientSetTransmit);
-	SDKHook(client, SDKHook_PreThink, SDKHookCB_ClientPreThink);
 }
 
 public Action SDKHookCB_ClientSetTransmit(int entity, int client)
@@ -33,9 +32,4 @@ public Action SDKHookCB_OwnedEntitySetTransmit(int entity, int client)
 	}
 	
 	return Plugin_Continue;
-}
-
-public void SDKHookCB_ClientPreThink(int client)
-{
-	Timer_OnClientThink(client);
 }

--- a/addons/sourcemod/scripting/deathrun/stocks.sp
+++ b/addons/sourcemod/scripting/deathrun/stocks.sp
@@ -90,3 +90,14 @@ stock void RemoveEdictAlwaysTransmitFlag(int edict)
 			SetEdictFlags(edict, (GetEdictFlags(edict) & ~FL_EDICT_ALWAYS));
 	}
 }
+
+stock int GetAliveClientCount()
+{
+	int count = 0;
+	for (int client = 1; client <= MaxClients; client++)
+	{
+		if (IsClientInGame(client) && IsPlayerAlive(client))
+			count++;
+	}
+	return count;
+}

--- a/addons/sourcemod/scripting/deathrun/stocks.sp
+++ b/addons/sourcemod/scripting/deathrun/stocks.sp
@@ -101,3 +101,11 @@ stock int GetAliveClientCount()
 	}
 	return count;
 }
+
+stock void PrintMessage(int client, const char[] format, any...)
+{
+	char message[256];
+	VFormat(message, sizeof(message), format, 3);
+	Format(message, sizeof(message), "[{primary}"...PLUGIN_NAME..."{default}] %s", message);
+	CPrintToChat(client, message);
+}

--- a/addons/sourcemod/scripting/deathrun/timers.sp
+++ b/addons/sourcemod/scripting/deathrun/timers.sp
@@ -20,6 +20,6 @@ public Action Timer_PrintChatTip(Handle timer)
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client) && !DRPlayer(client).HasPreference(Preference_HideChatTips))
-			PrintLocalizedMessage(client, "%t", tip);
+			PrintMessage(client, "%t", tip);
 	}
 }

--- a/addons/sourcemod/scripting/deathrun/timers.sp
+++ b/addons/sourcemod/scripting/deathrun/timers.sp
@@ -58,10 +58,9 @@ public Action Timer_ExplodePlayers(Handle timer)
 				if (IsPlayerAlive(client) && TF2_GetClientTeam(client) == TFTeam_Runners)
 					SDKHooks_TakeDamage(client, activator, 0, float(INTEGER_MAX_VALUE), DMG_BLAST);
 			}
-			
-			//No, this is not a bug ;)
-			EmitSoundToAll(TIMER_EXPLOSION_SOUND);
 		}
+		
+		EmitGameSoundToAll(GAMESOUND_EXPLOSION);
 	}
 }
 

--- a/addons/sourcemod/scripting/deathrun/timers.sp
+++ b/addons/sourcemod/scripting/deathrun/timers.sp
@@ -1,8 +1,3 @@
-static float g_TimerStartTime;
-static float g_TimerEndTime;
-
-static Handle g_RoundTimerHudSync;
-
 static char g_ChatTips[][] =  {
 	"ChatTip_HideRunners", 
 	"ChatTip_ActivatorWeapons", 
@@ -11,57 +6,10 @@ static char g_ChatTips[][] =  {
 	"ChatTip_DisableActivator"
 };
 
-void Timer_Init()
+void Timers_Init()
 {
-	g_RoundTimerHudSync = CreateHudSynchronizer();
-	
 	if (dr_chattips_interval.IntValue > 0)
 		CreateTimer(dr_chattips_interval.FloatValue, Timer_PrintChatTip, _, TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
-}
-
-void Timer_OnRoundStart()
-{
-	g_TimerStartTime = GetGameTime();
-	g_TimerEndTime = g_TimerStartTime + dr_round_time.FloatValue;
-	
-	if (g_TimerEndTime > g_TimerStartTime)
-		g_RoundTimer = CreateTimer(g_TimerEndTime - g_TimerStartTime, Timer_ExplodePlayers, _, TIMER_FLAG_NO_MAPCHANGE);
-}
-
-void Timer_OnClientThink(int client)
-{
-	if (g_TimerEndTime > g_TimerStartTime && g_RoundTimer != null)
-	{
-		float timeLeft = g_TimerEndTime - GetGameTime();
-		if (timeLeft >= 0)
-		{
-			int mins = RoundToFloor(timeLeft) / 60 % 60;
-			int secs = RoundToFloor(timeLeft) % 60;
-			ShowSyncHudText(client, g_RoundTimerHudSync, "Round time left: %02d:%02d", mins, secs);
-			SetHudTextParams(-1.0, 0.925, 0.1, 0, 255, 255, 255);
-		}
-	}
-}
-
-public Action Timer_ExplodePlayers(Handle timer)
-{
-	if (timer != g_RoundTimer)
-		return;
-	
-	int activator = GetActivator();
-	if (activator != -1)
-	{
-		for (int client = 1; client <= MaxClients; client++)
-		{
-			if (IsClientInGame(client))
-			{
-				if (IsPlayerAlive(client) && TF2_GetClientTeam(client) == TFTeam_Runners)
-					SDKHooks_TakeDamage(client, activator, 0, float(INTEGER_MAX_VALUE), DMG_BLAST);
-			}
-		}
-		
-		EmitGameSoundToAll(GAMESOUND_EXPLOSION);
-	}
 }
 
 public Action Timer_PrintChatTip(Handle timer)

--- a/addons/sourcemod/translations/deathrun.phrases.txt
+++ b/addons/sourcemod/translations/deathrun.phrases.txt
@@ -67,7 +67,7 @@
 	"RoundStart_NewActivator_Runners"
 	{
 		"#format"	"{1:s}"
-		"en"		"{1} became the Activator!\nAvoid getting killed by the traps\nand bring your team to the victory!"
+		"en"		"{1} became the Activator!\nAvoid getting killed by the traps\nand bring your team to victory!"
 	}
 	"RoundStart_NewActivator_Activator"
 	{

--- a/addons/sourcemod/translations/deathrun.phrases.txt
+++ b/addons/sourcemod/translations/deathrun.phrases.txt
@@ -27,23 +27,23 @@
 	
 	"ChatTip_HideRunners"
 	{
-		"en"	"{green}PROTIP: {default}As a Runner, you can hide teammates blocking your sight by using {orange}!drhide{default}."
+		"en"	"{green}PROTIP: {default}As a {red}Runner{default}, you can hide teammates blocking your sight with {secondary}!drhide{default}."
 	}
 	"ChatTip_ActivatorWeapons"
 	{
-		"en"	"{green}PROTIP: {default}As the Activator, utilize ranged weapons to hit traps from far away."
+		"en"	"{green}PROTIP: {default}As the {blue}Activator{default}, utilize ranged weapons to hit traps from far away."
 	}
 	"ChatTip_CheckQueue"
 	{
-		"en"	"{green}PROTIP: {default}You can check the queue of Activators using {orange}!drnext{default}."
+		"en"	"{green}PROTIP: {default}You can check the queue with {secondary}!drnext{default}."
 	}
 	"ChatTip_DisableChatTips"
 	{
-		"en"	"{green}PROTIP: {default}You can disable these tips using {orange}!drsettings{default}."
+		"en"	"{green}PROTIP: {default}You can disable these chat tips with {secondary}!drsettings{default}."
 	}
 	"ChatTip_DisableActivator"
 	{
-		"en"	"{green}PROTIP: {default}Don't want to play as the Activator? Change your Activator preferences using {orange}!drsettings{default}."
+		"en"	"{green}PROTIP: {default}Don't want to play as the {blue}Activator{default}? Change your preferences using {secondary}!drsettings{default}."
 	}
 	
 	"Thirdperson_ForceDisable"
@@ -81,12 +81,12 @@
 	"Preferences_Enabled"
 	{
 		"#format"	"{1:s}"
-		"en"		"You have successfully enabled the setting \"{1}\"."
+		"en"		"You have successfully {green}enabled {default}the setting {secondary}{1}{default}."
 	}
 	"Preferences_Disabled"
 	{
 		"#format"	"{1:s}"
-		"en"		"You have successfully disabled the setting \"{1}\"."
+		"en"		"You have successfully {red}disabled {default}the setting {secondary}{1}{default}."
 	}
 	
 	"Preference_DontBeActivator"


### PR DESCRIPTION
Thanks to @worMatty for suggesting me to make these changes.

Changelog for 1.2:
- Minimize the amount of HUD text channels used and use channel 5 where applicable
- Use arena's own ``team_round_timer`` entity for the round timer
- Remove the extremely loud explosion at the end of the round timer
- Add ConVar ``dr_runner_glow`` which can be used to enable/disable the player outline, default is ``0``
- Fix a client issue with Thermal Thruster particles being visible at all times
- Minor code improvements
- Updated the localization files