### PR TITLE
Dynamic Activator Health

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Inspired by the plugins I played many years back that were never made accessible
 * Activator queue system
 * Built-in third-person mode (can be disabled by server operators using ``dr_allow_thirdperson``)
 * Little to no restrictions on equipped weapons
-* Buffed activator health for combat minigames
+* Dynamic Activator health for combat minigames
 * Configurable round timer
 
 ## Dependencies

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -295,7 +295,7 @@ static Action OnClientSoundPlayed(int clients[MAXPLAYERS], int &numClients, int 
 	return action;
 }
 
-stock void UpdateActivatorHealth(int value, bool refillHealth)
+void UpdateActivatorHealth(int value, bool refill)
 {
 	for (int i = 0; i < g_CurrentActivators.Length; i++)
 	{
@@ -308,7 +308,7 @@ stock void UpdateActivatorHealth(int value, bool refillHealth)
 				TF2Attrib_SetValue(address, TF2Attrib_GetValue(address) + float(value) / dr_num_activators.FloatValue);
 				TF2Attrib_ClearCache(activator);
 				
-				if (refillHealth)
+				if (refill)
 					SetEntityHealth(activator, TF2_GetMaxHealth(activator) + value / dr_num_activators.IntValue);
 			}
 			else

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -305,7 +305,7 @@ void UpdateActivatorHealth(int value, bool refill)
 			Address address = TF2Attrib_GetByName(activator, "max health additive bonus");
 			if (address != Address_Null)
 			{
-				TF2Attrib_SetValue(address, TF2Attrib_GetValue(address) + float(value) / dr_num_activators.FloatValue);
+				TF2Attrib_SetValue(address, FloatMax(TF2Attrib_GetValue(address) + float(value) / dr_num_activators.FloatValue, 0.0));
 				TF2Attrib_ClearCache(activator);
 				
 				if (refill)

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -107,7 +107,6 @@ ConVar dr_allow_thirdperson;
 ConVar dr_chattips_interval;
 ConVar dr_runner_glow;
 ConVar dr_num_activators;
-ConVar dr_activator_health;
 
 ArrayList g_CurrentActivators;
 
@@ -209,6 +208,8 @@ public void OnClientDisconnect(int client)
 		g_CurrentActivators.Erase(index);
 	
 	DRPlayer(client).Reset();
+	
+	UpdateActivatorHealth(-TF2_GetMaxHealth(client), false);
 }
 
 public void OnEntityCreated(int entity, const char[] classname)
@@ -292,4 +293,28 @@ static Action OnClientSoundPlayed(int clients[MAXPLAYERS], int &numClients, int 
 	}
 	
 	return action;
+}
+
+stock void UpdateActivatorHealth(int value, bool refillHealth)
+{
+	for (int i = 0; i < g_CurrentActivators.Length; i++)
+	{
+		int activator = g_CurrentActivators.Get(i);
+		if (IsClientInGame(activator))
+		{
+			Address address = TF2Attrib_GetByName(activator, "max health additive bonus");
+			if (address != Address_Null)
+			{
+				TF2Attrib_SetValue(address, TF2Attrib_GetValue(address) + float(value) / dr_num_activators.FloatValue);
+				TF2Attrib_ClearCache(activator);
+				
+				if (refillHealth)
+					SetEntityHealth(activator, TF2_GetMaxHealth(activator) + value / dr_num_activators.IntValue);
+			}
+			else
+			{
+				LogError("Couldn't find attribute 'max health additive bonus' on activator");
+			}
+		}
+	}
 }

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -309,11 +309,7 @@ void UpdateActivatorHealth(int value, bool refill)
 				TF2Attrib_ClearCache(activator);
 				
 				if (refill)
-					SetEntityHealth(activator, TF2_GetMaxHealth(activator) + value / dr_num_activators.IntValue);
-			}
-			else
-			{
-				LogError("Couldn't find attribute 'max health additive bonus' on activator");
+					SetEntityHealth(activator, GetEntProp(activator, Prop_Send, "m_iHealth") + value / dr_num_activators.IntValue);
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -222,14 +222,14 @@ void Config_Apply(int client)
 								Address address = TF2Attrib_GetByName(item, attribute.name);
 								TF2Attrib_SetValue(address, TF2Attrib_GetValue(address) + attribute.value);
 								TF2Attrib_ClearCache(item);
-								TF2Attrib_ClearCache(GetEntProp(item, Prop_Data, "m_hOwnerEntity"));
+								TF2Attrib_ClearCache(GetEntPropEnt(item, Prop_Data, "m_hOwnerEntity"));
 							}
 							case ModMode_Subtract:
 							{
 								Address address = TF2Attrib_GetByName(item, attribute.name);
 								TF2Attrib_SetValue(address, TF2Attrib_GetValue(address) - attribute.value);
 								TF2Attrib_ClearCache(item);
-								TF2Attrib_ClearCache(GetEntProp(item, Prop_Data, "m_hOwnerEntity"));
+								TF2Attrib_ClearCache(GetEntPropEnt(item, Prop_Data, "m_hOwnerEntity"));
 							}
 							case ModMode_Remove:
 							{

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -15,7 +15,6 @@ void ConVars_Init()
 	dr_chattips_interval = CreateConVar("dr_chattips_interval", "240", "How often in seconds chat tips should be shown to clients. Set to 0 to disable chat tips.");
 	dr_runner_glow = CreateConVar("dr_runner_glow", "0", "Whether runners should have a glowing outline.");
 	dr_num_activators = CreateConVar("dr_num_activators", "1", "Amount of activators chosen at the start of a round.", _, true, 1.0, true, float(MaxClients - 1));
-	dr_activator_health = CreateConVar("dr_activator_health", "1000", "Maximum health of the activator.", _, true, 1.0);
 	
 	HookConVarChange(dr_allow_thirdperson, ConVarChanged_AllowThirdPerson);
 	HookConVarChange(dr_runner_glow, ConVarChanged_RunnerGlow);

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -1,5 +1,3 @@
-static Handle g_ActivatorHealthTimers[TF_MAXPLAYERS];
-
 void Events_Init()
 {
 	HookEvent("arena_round_start", EventHook_ArenaRoundStart);
@@ -82,11 +80,7 @@ public Action EventHook_PlayerDeath_Pre(Event event, const char[] name, bool don
 	
 	if (GameRules_GetRoundState() == RoundState_Stalemate && !DRPlayer(victim).IsActivator())
 	{
-		Handle timer = g_ActivatorHealthTimers[victim];
-		if (timer != null) //Did the victim die before the activators ever got their health?
-			delete timer;
-		else
-			UpdateActivatorHealth(-TF2_GetMaxHealth(victim), false);
+		UpdateActivatorHealth(-TF2_GetMaxHealth(victim), false);
 		
 		//Rewrite death event to credit activator
 		if (g_CurrentActivators.Length == 1)
@@ -109,7 +103,7 @@ public Action EventHook_PostInventoryApplication(Event event, const char[] name,
 	
 	//If this is a latespawn, give the activator health
 	if (GameRules_GetRoundState() == RoundState_Stalemate && !DRPlayer(client).IsActivator())
-		g_ActivatorHealthTimers[client] = CreateTimer(0.2, Timer_UpdateActivatorHealth, userid);
+		CreateTimer(0.2, Timer_UpdateActivatorHealth, userid);
 	
 	if (DRPlayer(client).InThirdPerson)
 		CreateTimer(0.2, Timer_SetThirdPerson, userid);

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -12,11 +12,11 @@ public Action EventHook_ArenaRoundStart(Event event, const char[] name, bool don
 	int numActivators;
 	
 	//Calculate max health to grant to activators
-	int maxhealth;
+	int maxHealth;
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client) && TF2_GetClientTeam(client) == TFTeam_Runners)
-			maxhealth += TF2_GetMaxHealth(client);
+			maxHealth += TF2_GetMaxHealth(client);
 	}
 	
 	//Iterate all chosen activators and check if they are still in-game
@@ -25,8 +25,8 @@ public Action EventHook_ArenaRoundStart(Event event, const char[] name, bool don
 		int activator = g_CurrentActivators.Get(i);
 		if (IsClientInGame(activator))
 		{
-			TF2Attrib_SetByName(activator, "max health additive bonus", float(maxhealth) / dr_num_activators.FloatValue);
-			SetEntityHealth(activator, TF2_GetMaxHealth(activator) + maxhealth / dr_num_activators.IntValue);
+			TF2Attrib_SetByName(activator, "max health additive bonus", float(maxHealth) / dr_num_activators.FloatValue);
+			SetEntityHealth(activator, TF2_GetMaxHealth(activator) + maxHealth / dr_num_activators.IntValue);
 			
 			numActivators++;
 		}

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -78,7 +78,6 @@ public Action EventHook_PlayerDeath_Pre(Event event, const char[] name, bool don
 {
 	int victim = GetClientOfUserId(event.GetInt("userid"));
 	
-	
 	if (GameRules_GetRoundState() == RoundState_Stalemate && !DRPlayer(victim).IsActivator())
 	{
 		//Reduce activator health for every dead runner
@@ -101,11 +100,11 @@ public Action EventHook_PostInventoryApplication(Event event, const char[] name,
 	int userid = event.GetInt("userid");
 	int client = GetClientOfUserId(userid);
 	
-	//If this is a latespawn, give the activator health
-	if (GameRules_GetRoundState() == RoundState_Stalemate)
-		CreateTimer(0.2, Timer_UpdateActivatorHealth, GetClientUserId(client));
-	
 	Config_Apply(client);
+	
+	//If this is a latespawn, give the activator health
+	if (GameRules_GetRoundState() == RoundState_Stalemate && !DRPlayer(client).IsActivator())
+		CreateTimer(0.2, Timer_UpdateActivatorHealth, GetClientUserId(client));
 	
 	if (DRPlayer(client).InThirdPerson)
 		CreateTimer(0.2, Timer_SetThirdPerson, userid);

--- a/addons/sourcemod/scripting/deathrun/stocks.sp
+++ b/addons/sourcemod/scripting/deathrun/stocks.sp
@@ -13,8 +13,8 @@ stock void StringToVector(const char[] buffer, float vec[3], float defvalue[3] =
 		return;
 	}
 	
-	char sPart[3][32];
-	int iReturned = ExplodeString(buffer, StrContains(buffer, ",") != -1 ? ", " : " ", sPart, 3, 32);
+	char parts[3][32];
+	int iReturned = ExplodeString(buffer, StrContains(buffer, ",") != -1 ? ", " : " ", parts, 3, 32);
 	
 	if (iReturned != 3)
 	{
@@ -24,9 +24,9 @@ stock void StringToVector(const char[] buffer, float vec[3], float defvalue[3] =
 		return;
 	}
 	
-	vec[0] = StringToFloat(sPart[0]);
-	vec[1] = StringToFloat(sPart[1]);
-	vec[2] = StringToFloat(sPart[2]);
+	vec[0] = StringToFloat(parts[0]);
+	vec[1] = StringToFloat(parts[1]);
+	vec[2] = StringToFloat(parts[2]);
 }
 
 stock float FloatMin(float a, float b)


### PR DESCRIPTION
Instead of a flat health value, activators now start with a health bonus equal to the combined maximum health of all runners.

As the runners die or disconnect, the maximum health of the activator decreases and the lost health remains as decaying overheal. If runners respawn during the round, health gets added again.

This aims to make combat minigames more fair by giving the activator a health pool roughly equal to the entire runner team.