### PR TITLE
Prevent unneeded respawns

### DIFF
--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -157,14 +157,14 @@ public Action EventHook_TeamplayRoundStart(Event event, const char[] name, bool 
 	}
 	
 	//New round has begun
+	Queue_SetNextActivatorsFromQueue();
+	
 	for (int client = 1; client <= MaxClients; client++)
 	{
-		//Put every player in the same team and pick the activator later
-		if (IsClientInGame(client) && TF2_GetClientTeam(client) > TFTeam_Spectator)
+		//Put every non-activators in the runners team
+		if (IsClientInGame(client) && TF2_GetClientTeam(client) > TFTeam_Spectator && !DRPlayer(client).IsActivator())
 			TF2_ChangeClientTeamAlive(client, TFTeam_Runners);
 	}
-	
-	Queue_SetNextActivatorsFromQueue();
 }
 
 public Action EventHook_TeamplayRoundWin(Event event, const char[] name, bool dontBroadcast)

--- a/addons/sourcemod/scripting/deathrun/stocks.sp
+++ b/addons/sourcemod/scripting/deathrun/stocks.sp
@@ -72,6 +72,9 @@ stock void TF2_ChangeClientTeamAlive(int client, TFTeam team)
 		TF2_SetPlayerClass(client, view_as<TFClassType>(GetRandomInt(1, 9)));
 	}
 	
+	if (TF2_GetClientTeam(client) == team && class != TFClass_Unknown)	//Already in same team
+		return;
+	
 	SetEntProp(client, Prop_Send, "m_lifeState", LIFE_DEAD);
 	TF2_ChangeClientTeam(client, team);
 	SetEntProp(client, Prop_Send, "m_lifeState", LIFE_ALIVE);


### PR DESCRIPTION
Everytime a new round starts, everyone spawned twice even if already in same team, and three times for activators, which leads to a possible [crash](https://crash.limetech.org/zrt7kycexmpu) for too many spawns at once, creating too many entities.

Figure out who is activators and respawn, then only respawn runners if not in correct team.