### PR TITLE
Release 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Deathrun Neu
-I was fed up with the lack of good public Deathrun plugins out there, so I went ahead and made my own.
-
-Inspired by the plugins I played many years back that were never made accessible to the public, this plugin aims to keep player restrictions as little as possible while not ruining the gameplay.
+Inspired by the plugins I played many years back that were never made accessible to the public, Deathrun Neu aims to keep weapon restrictions as little as possible while not ruining the core gameplay.
 
 ## Features
-* Activator queue system
-* Built-in third-person mode (can be disabled by server operators using ``dr_allow_thirdperson``)
-* Little to no restrictions on equipped weapons
-* Dynamic Activator health for combat minigames
+* Activator queue system (``!drnext``)
+* Ability to hide teammates in crowded areas (``!drhide``)
+* Built-in third-person mode (``!drthirdperson``)
+* Dynamic Activator health for fair combat minigames
+* Highly customizable item configuration
 * Configurable round timer
 
 ## Dependencies
@@ -17,17 +16,34 @@ Inspired by the plugins I played many years back that were never made accessible
 * [More Colors](https://forums.alliedmods.net/showthread.php?t=185016) (compile only)
 
 ## Configuration
-The item configuration found in ``configs/deathrun/items.cfg`` allows you to configure player items as you please. 
-For example, there are multiple ways to disable the jumping capabilities of the Ullapool Caber:
+The global item configuration found in ``configs/deathrun/items.cfg`` allows you to configure and restrict each player's items as you please.
+Map-specific configuration files are read from the ``configs/deathrun/maps`` directory.
 
+For example, there are two different ways to disable the jumping capabilities of the Ullapool Caber.
+
+Using attributes:
+```
+"307"	// Ullapool Caber
+{
+	"attributes"
+	{
+		"1"	// Zeroes out the self damage push force
+		{
+			"name"	"self dmg push force decreased"
+			"value"	"0.0"
+			"mode"	"set"
+		}
+	}
+}
+```
+Using entity properties:
 ```
 "307"	// Ullapool Caber
 {
 	"entprops"
 	{
-		"entprop"
+		"1"	// Sets the m_iDetonated entity prop to 1
 		{
-			// Sets the m_iDetonated entity prop to 1
 			"name"		"m_iDetonated"
 			"type"		"send"
 			"field_type"	"int"
@@ -36,19 +52,11 @@ For example, there are multiple ways to disable the jumping capabilities of the 
 	}
 }
 ```
-```
-"307"	// Ullapool Caber
-{
-	"attributes"
-	{
-		"attribute"
-		{
-			// Zeroes out the self damage push force
-			"name"	"self dmg push force decreased"
-			"value"	"0.0"
-			"mode"	"set"
-		}
-	}
-}
-```
-This repository already contains a configuration file that should suffice for most use cases.
+See [items.cfg](https://github.com/Mikusch/deathrun/blob/master/addons/sourcemod/configs/deathrun/items.cfg) for more details and the default configuration.
+
+### Map Configuration
+Some older maps have issues with players being able to activate buttons or kill other players through walls with explosive or throwable weapons. Instead of having to block these weapons in the global item configuration you have the option of creating a configuration file for each map.
+
+To do that, put a file called ``<map name>.items.cfg`` in the ``configs/deathrun/maps`` directory. Workshop prefixes and suffixes should be omitted.
+
+Any item definition indexes specified in a map-specific item configuration will override the global configuration.

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1,24 +1,35 @@
 // 
 // ITEM CONFIGURATION:
-//  This file is used to restrict player items, such as weapons and cosmetics.
+//  This file is used to modify items, such as weapons and cosmetics.
 //
 // The key of each configuration entry is the list of item definition indexes it applies to, separated by semicolons.
 //
 // Possible attributes:
-//  block_attack <bool>		- Whether the primary fire of this item should be blocked
-//  block_attack2 <bool>	- Whether the secondary fire of this item should be blocked
-//  remove <bool>			- Whether this item should be removed from the player
+//  block_attack <bool>		- Whether the primary fire of this item should be blocked, if applicable
+//  block_attack2 <bool>	- Whether the secondary fire of this item should be blocked, if applicable
+//  remove <bool>			- Whether this item should be removed from the player on spawn
 //  attributes <list>		- List of item attributes
 //  entprops <list>			- List of entity properties
 //
-"Items"
+"items"
 {
-	// Scout Primary
-	"45;1078"	// Force-A-Nature
+	// Scout - Primary [Slot 0]
+	"45"	// Force-A-Nature
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
+			{
+				"name"	"scattergun has knockback"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1078"	// Festive Force-A-Nature
+	{
+		"attributes"
+		{
+			"1"
 			{
 				"name"	"scattergun has knockback"
 				"value"	"0.0"
@@ -29,7 +40,7 @@
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"hype on damage"
 				"value"	"0.0"
@@ -37,8 +48,12 @@
 		}
 	}
 	
-	// Scout Secondary
-	"46;1145"	// Bonk! Atomic Punch
+	// Scout - Secondary [Slot 1]
+	"46"	// Bonk! Atomic Punch
+	{
+		"block_attack"	"1"
+	}
+	"1145"	// Festive Bonk!
 	{
 		"block_attack"	"1"
 	}
@@ -46,7 +61,7 @@
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"increased jump height from weapon"
 				"value"	"1.0"
@@ -54,12 +69,23 @@
 		}
 	}
 	
-	// Scout Melee
-	"325;452"	// Boston Basher
+	// Scout - Melee [Slot 2]
+	"325"	// Boston Basher
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
+			{
+				"name"	"hit self on miss"	// Can be used to get to higher spots
+				"value"	"0.0"
+			}
+		}
+	}
+	"452"	// Three-Rune Blade
+	{
+		"attributes"
+		{
+			"1"
 			{
 				"name"	"hit self on miss"	// Can be used to get to higher spots
 				"value"	"0.0"
@@ -70,7 +96,7 @@
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"air dash count"
 				"value"	"0.0"
@@ -78,12 +104,353 @@
 		}
 	}
 	
-	// Soldier Primary
-	"18;205;127;228;237;414;441;513;658;730;800;809;889;898;907;916;965;974;1085;1104;15006;15014;15028;15043;15052;15057;15081;15104;15105;15129;15130;15150"	// Every Rocket Launcher
+	// Soldier - Primary [Slot 0]
+	"18"	// Rocket Launcher
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"205"	// Rocket Launcher (Renamed/Strange)
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"127"	// The Direct Hit
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"228"	// The Black Box
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"237"	// Rocket Jumper
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"414"	// The Liberty Launcher
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"441"	// The Cow Mangler 5000
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"513"	// The Original
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"658"	// Festive Rocket Launcher
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"730"	// The Beggar's Bazooka
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"800"	// Silver Botkiller Rocket Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"809"	// Gold Botkiller Rocket Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"889"	// Rust Botkiller Rocket Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"898"	// Blood Botkiller Rocket Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"907"	// Carbonado Botkiller Rocket Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"916"	// Diamond Botkiller Rocket Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"965"	// Silver Botkiller Rocket Launcher Mk.II
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"974"	// Gold Botkiller Rocket Launcher Mk.II
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1085"	// Festive Black Box
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1104"	// The Air Strike
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15006"	// Woodland Warrior
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15014"	// Sand Cannon
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15028"	// American Pastoral
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15043"	// Smalltown Bringdown
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15052"	// Shell Shocker
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15057"	// Aqua Marine
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15081"	// Autumn
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15104"	// Blue Mew
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15105"	// Brain Candy
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15129"	// Coffin Nail
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15130"	// High Roller's
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15150"	// Warhawk
+	{
+		"attributes"
+		{
+			"1"
 			{
 				"name"	"self dmg push force decreased"
 				"value"	"0.0"
@@ -91,12 +458,56 @@
 		}
 	}
 	
-	// Pyro Secondary
-	"39;351;595;740;1081"	// Every Flare Gun
+	// Pyro - Secondary [Slot 1]
+	"39"	// The Flare Gun
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"351"	// The Detonator
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"595"	// The Manmelter
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"740"	// The Scorch Shot
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1081"	// Festive Flare Gun
+	{
+		"attributes"
+		{
+			"1"
 			{
 				"name"	"self dmg push force decreased"
 				"value"	"0.0"
@@ -107,7 +518,7 @@
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"item_meter_charge_rate"
 				"value"	"-1.0"
@@ -115,12 +526,155 @@
 		}
 	}
 	
-	// Demoman Primary
-	"19;206;308;996;1007;1151;15077;15079;15091;15092;15116;15117;15142;15158"	// Every Grenade Launcher
+	// Demoman - Primary [Slot 0]
+	"19"	// Grenade Launcher
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"206"	// Grenade Launcher (Renamed/Strange)
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"308"	// The Loch-n-Load
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"996"	// The Loose Cannon
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1007"	// Festive Grenade Launcher
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1151"	// The Iron Bomber
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15077"	// Autumn
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15079"	// Macabre Web
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15091"	// Rainbow
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15092"	// Sweet Dreams
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15116"	// Coffin Nail
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15117"	// Top Shelf
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15142"	// Warhawk
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15158"	// Butcher Bird
+	{
+		"attributes"
+		{
+			"1"
 			{
 				"name"	"self dmg push force decreased"
 				"value"	"0.0"
@@ -128,23 +682,342 @@
 		}
 	}
 	
-	// Demoman Secondary
-	"20;207;130;265;661;797;806;886;895;904;913;962;971;1150;15009;15012;15024;15038;15045;15048;15082;15083;15084;15113;15137;15138;15155"	// Every Stickybomb Launcher
+	// Scout - Secondary [Slot 1]
+	"20"	// Stickybomb Launcher
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"self dmg push force decreased"
 				"value"	"0.0"
 			}
 		}
 	}
-	"131;406;1099;1144"	// Every Demoman Shield
+	"207"	// Stickybomb Launcher (Renamed/Strange)
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"130"	// The Scottish Resistance
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"265"	// Sticky Jumper
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"661"	// Festive Stickybomb Launcher
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"797"	// Silver Botkiller Stickybomb Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"806"	// Gold Botkiller Stickybomb Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"886"	// Rust Botkiller Stickybomb Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"895"	// Blood Botkiller Stickybomb Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"904"	// Carbonado Botkiller Stickybomb Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"913"	// Diamond Botkiller Stickybomb Launcher Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"962"	// Silver Botkiller Stickybomb Launcher Mk.II
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"971"	// Gold Botkiller Stickybomb Launcher Mk.II
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1150"	// The Quickiebomb Launcher
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15009"	// Sudden Flurry
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15012"	// Carpet Bomber
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15024"	// Blasted Bombardier
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15038"	// Rooftop Wrangler
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15045"	// Liquid Asset
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15048"	// Pink Elephant
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15082"	// Autumn
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15083"	// Pumpkin Patch
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15084"	// Macabre Web
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15113"	// Sweet Dreams
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15137"	// Coffin Nail
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15138"	// Dressed to Kill
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15155"	// Blitzkrieg
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"131"	// The Chargin' Targe
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"charge time decreased"
+				"value"	"-1.5"
+			}
+		}
+	}
+	"406"	// The Splendid Screen
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"charge time decreased"
+				"value"	"-1.5"
+			}
+		}
+	}
+	"1099"	// The Tide Turner
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"charge time decreased"
+				"value"	"-1.5"
+			}
+		}
+	}
+	"1144"	// Festive Targe
+	{
+		"attributes"
+		{
+			"1"
 			{
 				"name"	"charge time decreased"
 				"value"	"-1.5"
@@ -152,12 +1025,12 @@
 		}
 	}
 	
-	// Demoman Melee
+	// Demoman - Melee [Slot 2]
 	"307"	// Ullapool Caber
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"self dmg push force decreased"
 				"value"	"0.0"
@@ -168,7 +1041,7 @@
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"charge time increased"
 				"value"	"0.0"
@@ -176,12 +1049,67 @@
 		}
 	}
 	
-	// Heavy Secondary
-	"42;159;433;863;1002;1190"	// All Lunchbox Items
+	// Heavy - Secondary [Slot 1]
+	"42"	// Sandvich
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
+			{
+				"name"	"lunchbox healing decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"159"	// The Dalokohs Bar
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"lunchbox healing decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"433"	// Fishcake
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"lunchbox healing decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"863"	// Robo-Sandvich
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"lunchbox healing decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1002"	// Festive Sandvich
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"lunchbox healing decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1190"	// Second Banana
+	{
+		"attributes"
+		{
+			"1"
 			{
 				"name"	"lunchbox healing decreased"
 				"value"	"0.0"
@@ -189,12 +1117,12 @@
 		}
 	}
 	
-	// Engineer Melee
+	// Engineer - Melee [Slot 2]
 	"589"	// Eureka Effect
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"alt fire teleport to spawn"
 				"value"	"0.0"
@@ -202,30 +1130,441 @@
 		}
 	}
 	
-	// Medic Primary
-	"305;1079"	// Crusader's Crossbow
+	// Medic - Primary [Slot 0]
+	"305"	// Crusader's Crossbow
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
-				"name"	"damage penalty"	// Prevents healing
+				"name"	"damage penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1079"	// Festive Crusader's Crossbow
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"damage penalty"
 				"value"	"0.0"
 			}
 		}
 	}
 	
-	// Medic Secondary
-	"29;211;35;411;663;796;805;885;894;903;912;961;970;998;15008;15010;15025;15039;15050;15078;15097;15121;15122;15123;15145;15146"	// Every Medi Gun
+	// Medic - Seconday [Slot 1]
+	"29"	// Medi Gun
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"attribute"
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"211"	// Medi Gun(Renamed/Strange)
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"35"	// The Kritzkrieg
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"411"	// The Quick-Fix
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"663"	// Festive Medi Gun
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"796"	// Silver Botkiller Medi Gun Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"805"	// Gold Botkiller Medi Gun Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"885"	// Rust Botkiller Medi Gun Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"894"	// Blood Botkiller Medi Gun Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"903"	// Carbonado Botkiller Medi Gun Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"912"	// Diamond Botkiller Medi Gun Mk.I
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"961"	// Silver Botkiller Medi Gun Mk.II
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"970"	// Gold Botkiller Medi Gun Mk.II
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"998"	// The Vaccinator
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15008"	// Masked Mender
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15010"	// Wrapped Reviver
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15025"	// Reclaimed Reanimator
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15039"	// Civil Servant
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15050"	// Spark of Life
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15078"	// Wildwood
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15097"	// Flower Power
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15121"	// Dressed To Kill
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15122"	// High Roller's
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15123"	// Coffin Nail
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15145"	// Blitzkrieg
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.0"
+			}
+		}
+	}
+	"15146"	// Corsair
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"heal rate penalty"
+				"value"	"0.0"
+			}
+			"2"
 			{
 				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
@@ -233,12 +1572,12 @@
 		}
 	}
 	
-	// Medic Melee
+	// Medic - Melee [Slot 2]
 	"304"	// Amputator
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"enables aoe heal"
 				"value"	"0.0"
@@ -246,18 +1585,38 @@
 		}
 	}
 	
-	// Spy PDA
-	"30;59;60;212;297;947"	// All Invis Watches
+	// Spy - PDA2 [Slot 4]
+	"30"	// Invis Watch
+	{
+		"remove"	"1"
+	}
+	"212"	// Invis Watch (Renamed/Strange)
+	{
+		"remove"	"1"
+	}
+	"59"	// The Dead Ringer
+	{
+		"remove"	"1"
+	}
+	"60"	// The Cloak and Dagger
+	{
+		"remove"	"1"
+	}
+	"297"	// Enthusiast's Timepiece
+	{
+		"remove"	"1"
+	}
+	"947"	// The Quackenbirdt
 	{
 		"remove"	"1"
 	}
 	
-	// Multi-Class Secondary
+	// Multi-Class - Secondary [Slot 1]
 	"1101"	// The B.A.S.E. Jumper
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"parachute attribute"
 				"value"	"0.0"
@@ -265,12 +1624,12 @@
 		}
 	}
 	
-	// Multi-Class Melee
+	// Multi-Class - Melee [Slot 2]
 	"357"	// Half-Zatoichi
 	{
 		"attributes"
 		{
-			"attribute"
+			"1"
 			{
 				"name"	"honorbound"
 				"value"	"0.0"
@@ -278,7 +1637,7 @@
 		}
 	}
 	
-	// Cosmetics
+	// Action Items/Cosmetics [Slot 7-10]
 	"5869"	// Jungle Inferno ConTracker
 	{
 		// HACK: This item never passes through a SetTransmit hook due to an attached particle having EF_EDICT_ALWAYS set

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1,8 +1,8 @@
 // 
 // ITEM CONFIGURATION:
-//  This file is used to modify items, such as weapons and cosmetics.
+//  This file is used to configure items, such as weapons and cosmetics.
 //
-// The key of each configuration entry is the list of item definition indexes it applies to, separated by semicolons.
+// The key of each configuration entry is the item definition index of the item it applies to.
 //
 // Possible attributes:
 //  block_attack <bool>		- Whether the primary fire of this item should be blocked, if applicable
@@ -11,7 +11,7 @@
 //  attributes <list>		- List of item attributes
 //  entprops <list>			- List of entity properties
 //
-"items"
+"Items"
 {
 	// Scout - Primary [Slot 0]
 	"45"	// Force-A-Nature
@@ -682,7 +682,7 @@
 		}
 	}
 	
-	// Scout - Secondary [Slot 1]
+	// Demoman - Secondary [Slot 1]
 	"20"	// Stickybomb Launcher
 	{
 		"attributes"
@@ -1154,7 +1154,7 @@
 		}
 	}
 	
-	// Medic - Seconday [Slot 1]
+	// Medic - Secondary [Slot 1]
 	"29"	// Medi Gun
 	{
 		"attributes"

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1648,10 +1648,15 @@
 		{
 			"1"
 			{
-				"name"	"mult cloak meter regen rate"
+				"name"	"set cloak is movement based"
 				"value"	"0.0"
 			}
 			"2"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"3"
 			{
 				"name"	"ReducedCloakFromAmmo"
 				"value"	"0.0"

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -458,6 +458,24 @@
 		}
 	}
 	
+	// Soldier - Melee [Slot 2]
+	"775"	// Escape Plan
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"mod shovel speed boost"
+				"value"	"1.0"
+			}
+			"2"
+			{
+				"name"	"self mark for death"
+				"value"	"0.0"
+			}
+		}
+	}
+	
 	// Pyro - Secondary [Slot 1]
 	"39"	// The Flare Gun
 	{
@@ -986,8 +1004,8 @@
 		{
 			"1"
 			{
-				"name"	"charge time decreased"
-				"value"	"-1.5"
+				"name"	"charge recharge rate increased"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -997,8 +1015,8 @@
 		{
 			"1"
 			{
-				"name"	"charge time decreased"
-				"value"	"-1.5"
+				"name"	"charge recharge rate increased"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1008,8 +1026,8 @@
 		{
 			"1"
 			{
-				"name"	"charge time decreased"
-				"value"	"-1.5"
+				"name"	"charge recharge rate increased"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1019,8 +1037,8 @@
 		{
 			"1"
 			{
-				"name"	"charge time decreased"
-				"value"	"-1.5"
+				"name"	"charge recharge rate increased"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1037,13 +1055,13 @@
 			}
 		}
 	}
-	"327"	// The Claidheamh Mòr
+	"404"	// The Persian Persuader
 	{
 		"attributes"
 		{
 			"1"
 			{
-				"name"	"charge time increased"
+				"name"	"ammo gives charge"
 				"value"	"0.0"
 			}
 		}
@@ -1588,27 +1606,89 @@
 	// Spy - PDA2 [Slot 4]
 	"30"	// Invis Watch
 	{
-		"remove"	"1"
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+		}
 	}
 	"212"	// Invis Watch (Renamed/Strange)
 	{
-		"remove"	"1"
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+		}
 	}
 	"59"	// The Dead Ringer
 	{
-		"remove"	"1"
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ReducedCloakFromAmmo"
+				"value"	"0.0"
+			}
+		}
 	}
 	"60"	// The Cloak and Dagger
 	{
-		"remove"	"1"
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ReducedCloakFromAmmo"
+				"value"	"0.0"
+			}
+		}
 	}
 	"297"	// Enthusiast's Timepiece
 	{
-		"remove"	"1"
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ReducedCloakFromAmmo"
+				"value"	"0.0"
+			}
+		}
 	}
 	"947"	// The Quackenbirdt
 	{
-		"remove"	"1"
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ReducedCloakFromAmmo"
+				"value"	"0.0"
+			}
+		}
 	}
 	
 	// Multi-Class - Secondary [Slot 1]

--- a/addons/sourcemod/configs/deathrun/maps/readme.txt
+++ b/addons/sourcemod/configs/deathrun/maps/readme.txt
@@ -1,0 +1,11 @@
+When the plugin loads, this folder is automatically scanned for map configuration files. Item definition indexes specified in such a file will always override matching ones in the global configuration.
+
+The map configuration file should be named <map name>.items.cfg, omitting any workshop prefix and suffix.
+
+Examples:
+
+	dr_horrors -> dr_horrors.items.cfg
+	dr_paradoxal_v4 -> dr_paradoxal_v4.items.cfg
+	workshop/dr_scprun_v2.ugc2183648308 -> dr_scprun_v2.items.cfg
+
+The KV structure is identical to the global configuration. See items.cfg for more details.

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -33,7 +33,7 @@
 #define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
 #define PLUGIN_DESCRIPTION	"Team Fortress 2 Deathrun"
-#define PLUGIN_VERSION		"1.3.3"
+#define PLUGIN_VERSION		"1.4.0"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
 #define GAMESOUND_EXPLOSION		"MVM.BombExplodes"

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -153,7 +153,7 @@ void Config_Init()
 {
 	g_ItemConfig = new ItemConfigList();
 	
-	KeyValues kv = new KeyValues("items");
+	KeyValues kv = new KeyValues("Items");
 	char path[PLATFORM_MAX_PATH];
 	BuildPath(Path_SM, path, sizeof(path), "configs/deathrun/items.cfg");
 	if (kv.ImportFromFile(path))
@@ -166,7 +166,7 @@ void Config_Init()
 	GetCurrentMap(map, sizeof(map));
 	GetMapDisplayName(map, map, sizeof(map));
 	
-	kv = new KeyValues("items");
+	kv = new KeyValues("Items");
 	BuildPath(Path_SM, path, sizeof(path), "configs/deathrun/maps/%s.items.cfg", map);
 	if (kv.ImportFromFile(path))
 	{

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -93,6 +93,12 @@ enum struct ItemConfig
 			kv.GoBack();
 		}
 	}
+	
+	void Destroy()
+	{
+		delete this.attributes;
+		delete this.entprops;
+	}
 }
 
 methodmap ItemConfigList < ArrayList
@@ -115,11 +121,17 @@ methodmap ItemConfigList < ArrayList
 					ItemConfig item;
 					item.SetConfig(defindex, kv);
 					
+					ItemConfig oldItem;
 					int i = this.FindValue(defindex);
-					if (i != -1)
+					if (i != -1 && this.GetArray(i, oldItem) > 0)
+					{
+						oldItem.Destroy();
 						this.SetArray(i, item);
+					}
 					else
+					{
 						this.PushArray(item);
+					}
 				}
 			}
 			while (kv.GotoNextKey(false));

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -1,34 +1,14 @@
 #define ITEM_CONFIG_FILE	"configs/deathrun/items.cfg"
 
-enum AttributeModMode
-{
-	ModMode_Set,		/*< Sets the attribute's value, adding it if it doesn't exist */
-	ModMode_Add,		/*< Adds to the current value of the attribute */
-	ModMode_Subtract,	/*< Subtracts from the current value of the attribute */
-	ModMode_Remove		/*< Removes the attribute (static attributes can not be removed) */
-}
-
 enum struct ItemAttributeConfig
 {
 	char name[256];			/*< Attribute name */
 	float value;			/*< Attribute value */
-	AttributeModMode mode;	/*< How this attribute should be modified */
 	
 	void ReadConfig(KeyValues kv)
 	{
 		kv.GetString("name", this.name, 256);
 		this.value = kv.GetFloat("value");
-		
-		char mode[32];
-		kv.GetString("mode", mode, sizeof(mode));
-		if (StrEqual(mode, "set"))
-			this.mode = ModMode_Set;
-		else if (StrEqual(mode, "add"))
-			this.mode = ModMode_Add;
-		else if (StrEqual(mode, "subtract"))
-			this.mode = ModMode_Subtract;
-		else if (StrEqual(mode, "remove"))
-			this.mode = ModMode_Remove;
 	}
 }
 
@@ -211,31 +191,7 @@ void Config_Apply(int client)
 					ItemAttributeConfig attribute;
 					if (config.attributes.GetArray(i, attribute, sizeof(attribute)) > 0)
 					{
-						switch (attribute.mode)
-						{
-							case ModMode_Set:
-							{
-								TF2Attrib_SetByName(item, attribute.name, attribute.value);
-							}
-							case ModMode_Add:
-							{
-								Address address = TF2Attrib_GetByName(item, attribute.name);
-								TF2Attrib_SetValue(address, TF2Attrib_GetValue(address) + attribute.value);
-								TF2Attrib_ClearCache(item);
-								TF2Attrib_ClearCache(GetEntPropEnt(item, Prop_Data, "m_hOwnerEntity"));
-							}
-							case ModMode_Subtract:
-							{
-								Address address = TF2Attrib_GetByName(item, attribute.name);
-								TF2Attrib_SetValue(address, TF2Attrib_GetValue(address) - attribute.value);
-								TF2Attrib_ClearCache(item);
-								TF2Attrib_ClearCache(GetEntPropEnt(item, Prop_Data, "m_hOwnerEntity"));
-							}
-							case ModMode_Remove:
-							{
-								TF2Attrib_RemoveByName(item, attribute.name);
-							}
-						}
+						TF2Attrib_SetByName(item, attribute.name, attribute.value);
 					}
 				}
 				

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -110,16 +110,12 @@ methodmap ItemConfigList < ArrayList
 		{
 			do
 			{
-				char defindexes[PLATFORM_MAX_PATH];
-				kv.GetSectionName(defindexes, sizeof(defindexes));
-				
-				char parts[32][8]; // maximum 32 defindexes up to 8 characters
-				int retrieved = ExplodeString(defindexes, ";", parts, sizeof(parts), sizeof(parts[]));
-				
-				for (int i = 0; i < retrieved; i++)
+				char section[8];
+				int defindex;
+				if (kv.GetSectionName(section, sizeof(section)) && StringToIntEx(section, defindex) > 0)
 				{
 					ItemConfig item;
-					item.SetConfig(StringToInt(parts[i]), kv);
+					item.SetConfig(defindex, kv);
 					this.PushArray(item);
 				}
 			}
@@ -144,7 +140,7 @@ void Config_Init()
 	
 	char path[PLATFORM_MAX_PATH];
 	BuildPath(Path_SM, path, sizeof(path), ITEM_CONFIG_FILE);
-	KeyValues kv = new KeyValues("Items");
+	KeyValues kv = new KeyValues("items");
 	if (kv.ImportFromFile(path))
 	{
 		g_ItemConfig.ReadConfig(kv);

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -1,5 +1,3 @@
-#define ITEM_CONFIG_FILE	"configs/deathrun/items.cfg"
-
 enum struct ItemAttributeConfig
 {
 	char name[256];			/*< Attribute name */
@@ -116,7 +114,12 @@ methodmap ItemConfigList < ArrayList
 				{
 					ItemConfig item;
 					item.SetConfig(defindex, kv);
-					this.PushArray(item);
+					
+					int i = this.FindValue(defindex);
+					if (i != -1)
+						this.SetArray(i, item);
+					else
+						this.PushArray(item);
 				}
 			}
 			while (kv.GotoNextKey(false));
@@ -138,14 +141,27 @@ void Config_Init()
 {
 	g_ItemConfig = new ItemConfigList();
 	
-	char path[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, path, sizeof(path), ITEM_CONFIG_FILE);
 	KeyValues kv = new KeyValues("items");
+	char path[PLATFORM_MAX_PATH];
+	BuildPath(Path_SM, path, sizeof(path), "configs/deathrun/items.cfg");
 	if (kv.ImportFromFile(path))
 	{
 		g_ItemConfig.ReadConfig(kv);
 		kv.GoBack();
 	}
+	
+	char map[128];
+	GetCurrentMap(map, sizeof(map));
+	GetMapDisplayName(map, map, sizeof(map));
+	
+	kv = new KeyValues("items");
+	BuildPath(Path_SM, path, sizeof(path), "configs/deathrun/maps/%s.items.cfg", map);
+	if (kv.ImportFromFile(path))
+	{
+		g_ItemConfig.ReadConfig(kv);
+		kv.GoBack();
+	}
+	
 	delete kv;
 }
 


### PR DESCRIPTION
Breaking config changes in this release, anyone updating to it will have to update their config.

- Added support for map configuration files
  - Located in ``configs/deathrun/maps``
  - Items specified in a map-specific config file will override global config
- Removed the different attribute modes (``add``, ``subtract``, ``set``, ``remove``) because they were ultimately pointless and you could achieve everything using ``set``, which is now the only option
- Items now have to be specified separately instead of being able to separate them using semicolons
  - This significantly increases the size of the the config due to all the reskins but makes it clear which items get overridden by map-specific configs and doesn't overcomplicate the code