### PR TITLE
Use DHook methodmap API

### DIFF
--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -33,7 +33,7 @@
 #define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
 #define PLUGIN_DESCRIPTION	"Team Fortress 2 Deathrun"
-#define PLUGIN_VERSION		"1.4.0"
+#define PLUGIN_VERSION		"1.4.1"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
 #define GAMESOUND_EXPLOSION		"MVM.BombExplodes"

--- a/addons/sourcemod/scripting/deathrun/dhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/dhooks.sp
@@ -41,7 +41,7 @@ public MRESReturn DHook_SetWinningTeam_Pre(DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHookCallback_CalculateMaxSpeed_Post(int client, DHookReturn ret, DHookParam param)
+public MRESReturn DHookCallback_CalculateMaxSpeed_Post(int client, DHookReturn ret)
 {
 	//We don't want speedy scouts
 	if (IsClientInGame(client) && TF2_GetPlayerClass(client) == TFClass_Scout)

--- a/addons/sourcemod/scripting/deathrun/dhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/dhooks.sp
@@ -4,8 +4,7 @@ void DHooks_Init(GameData gamedata)
 {
 	g_DHookSetWinningTeam = DynamicHook.FromConf(gamedata, "CTeamplayRoundBasedRules::SetWinningTeam");
 	
-	DynamicDetour detour = DynamicDetour.FromConf(gamedata, "CTFPlayer::TeamFortress_CalculateMaxSpeed");
-	detour.Enable(Hook_Post, DHookCallback_CalculateMaxSpeed_Post);
+	DynamicDetour.FromConf(gamedata, "CTFPlayer::TeamFortress_CalculateMaxSpeed").Enable(Hook_Post, DHookCallback_CalculateMaxSpeed_Post);
 }
 
 void DHooks_HookGamerules()


### PR DESCRIPTION
The latest version of DHooks now has a methodmap API. The functionality is the same, it just looks cleaner and more modern.

* Replaced all DHook function calls with their methodmap equivalents
* Replaced all generic ``Handle`` types with new methodmap types
* Removed unnecessary parameters in callbacks
* Removed a fix for ``this`` pointer in post hooks being ``null`` as this was fixed in https://github.com/peace-maker/DHooks2/pull/8