### PR TITLE
Release 1.5.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: Mikusch
+patreon: Mikusch
+ko_fi: Mikusch

--- a/README.md
+++ b/README.md
@@ -1,27 +1,32 @@
 # Deathrun Neu
-Inspired by the plugins I played many years back that were never made accessible to the public, Deathrun Neu aims to keep weapon restrictions as little as possible while not ruining the core gameplay.
+
+Deathrun Neu is inspired by the plugins I played many years ago that were never made accessible to the public.
+It aims to keep weapon restrictions as little as possible while not ruining the core gameplay.
 
 ## Features
-* Activator queue system (`!drnext`)
-* Ability to hide teammates in crowded areas (`!drhide`)
-* Built-in third-person mode (`!drthirdperson`)
+
+* Activator queue system (`!drqueue`)
+* Ability to hide other players in crowded areas (`!drhide`)
 * Dynamic Activator health for fair combat minigames
-* Highly customizable item configuration
 * Configurable round timer (using the `tf_arena_round_time` ConVar)
+* Highly customizable item and plugin configuration
 
 ## Dependencies
+
 * SourceMod 1.10
 * [DHooks with Detour Support](https://forums.alliedmods.net/showpost.php?p=2588686&postcount=589)
 * [TF2Attributes](https://forums.alliedmods.net/showthread.php?t=210221)
 * [More Colors](https://forums.alliedmods.net/showthread.php?t=185016) (compile only)
 
 ## Configuration
-The global item configuration found in `configs/deathrun/items.cfg` allows you to configure and restrict each player's items as you please.
-Map-specific configuration files are read from the `configs/deathrun/maps` directory.
+
+The global item configuration found in `configs/deathrun/items.cfg` allows you to configure and restrict each player's
+items as you please. Map-specific configuration files are read from the `configs/deathrun/maps` directory.
 
 For example, there are two different ways to disable the jumping capabilities of the Ullapool Caber.
 
 Using attributes:
+
 ```
 "307"	// Ullapool Caber
 {
@@ -36,7 +41,9 @@ Using attributes:
 	}
 }
 ```
-Using entity properties:
+
+Using entity properties (advanced):
+
 ```
 "307"	// Ullapool Caber
 {
@@ -54,6 +61,7 @@ Using entity properties:
 ```
 
 These two methods may also be combined. For example, to give Medics a one-time use ÜberCharge that can not be rebuilt:
+
 ```
 "29"	// Medi Gun
 {
@@ -86,17 +94,36 @@ These two methods may also be combined. For example, to give Medics a one-time u
 See [items.cfg](/addons/sourcemod/configs/deathrun/items.cfg) for more details and the default configuration.
 
 ### Map Configuration
-Some older maps have issues with players being able to activate buttons or kill other players through walls with explosive or throwable weapons. Instead of having to block these weapons in the global item configuration you have the option of creating a configuration file for each map.
 
-To do that, put a file called `<map name>.items.cfg` in the `configs/deathrun/maps` directory. Workshop prefixes and suffixes should be omitted.
+Some older maps have issues with players being able to activate buttons or kill other players through walls with
+explosive or throwable weapons. Instead of having to block these weapons in the global item configuration you have the
+option of creating a configuration file for each map.
+
+To do that, put a file called `<map name>.items.cfg` in the `configs/deathrun/maps` directory. Workshop prefixes and
+suffixes should be omitted.
 
 Any item definition indexes specified in a map-specific item configuration will override the global configuration.
 
 ## ConVars
+
 - `dr_version` - Plugin version, don't touch.
 - `dr_queue_points ( def. "15" )` - Amount of queue points awarded to runners at the end of each round.
-- `dr_allow_thirdperson ( def. "1" )` - If enabled, players may toggle thirdperson. Set to 0 if you use other thirdperson plugins that may conflict.
-- `dr_chattips_interval ( def. "240" )` - Interval between helpful tips printed to chat, in seconds. Set to 0 to disable chat tips.
+- `dr_allow_thirdperson ( def. "1" )` - If enabled, players may toggle thirdperson. Set to 0 if you use other
+  thirdperson plugins that may conflict.
+- `dr_chattips_interval ( def. "240" )` - Interval between helpful tips printed to chat, in seconds. Set to 0 to disable
+  chat tips.
 - `dr_runner_glow ( def. "0" )` - If enabled, runners will have a glowing outline.
-- `dr_num_activators ( def. "1" )` - Amount of activators chosen at the start of a round.
+- `dr_activator_count ( def. "1" )` - Amount of activators chosen at the start of a round.
 - `dr_scout_speed_penalty ( def. "80.0" )` - Max speed penalty for Scouts, in HU/s.
+- `dr_activator_health_modifier ( def. "1.0" )` - Modifier of the health the activator receives from runners.
+- `dr_activator_healthbar ( def. "1" )` - If enabled, the activator health will be displayed on screen.
+- `dr_speed_modifier ( def. "0.0" )` - Maximum speed modifier for all classes, in HU/s.
+    - `dr_speed_modifier_scout ( def. "-80.0" )` - Maximum speed modifier for Scout, in HU/s.
+    - `dr_speed_modifier_sniper ( def. "0.0" )` - Maximum speed modifier for Sniper, in HU/s.
+    - `dr_speed_modifier_soldier ( def. "0.0" )` - Maximum speed modifier for Soldier, in HU/s.
+    - `dr_speed_modifier_demoman ( def. "0.0" )` - Maximum speed modifier for Demoman, in HU/s.
+    - `dr_speed_modifier_medic ( def. "0.0" )` - Maximum speed modifier for Medic, in HU/s.
+    - `dr_speed_modifier_heavy ( def. "0.0" )` - Maximum speed modifier for Heavy, in HU/s.
+    - `dr_speed_modifier_pyro ( def. "0.0" )` - Maximum speed modifier for Pyro, in HU/s.
+    - `dr_speed_modifier_spy ( def. "0.0" )` - Maximum speed modifier for Spy, in HU/s.
+    - `dr_speed_modifier_engineer ( def. "0.0" )` - Maximum speed modifier for Engineer, in HU/s.

--- a/README.md
+++ b/README.md
@@ -108,13 +108,10 @@ Any item definition indexes specified in a map-specific item configuration will 
 
 - `dr_version` - Plugin version, don't touch.
 - `dr_queue_points ( def. "15" )` - Amount of queue points awarded to runners at the end of each round.
-- `dr_allow_thirdperson ( def. "1" )` - If enabled, players may toggle thirdperson. Set to 0 if you use other
-  thirdperson plugins that may conflict.
 - `dr_chattips_interval ( def. "240" )` - Interval between helpful tips printed to chat, in seconds. Set to 0 to disable
   chat tips.
 - `dr_runner_glow ( def. "0" )` - If enabled, runners will have a glowing outline.
 - `dr_activator_count ( def. "1" )` - Amount of activators chosen at the start of a round.
-- `dr_scout_speed_penalty ( def. "80.0" )` - Max speed penalty for Scouts, in HU/s.
 - `dr_activator_health_modifier ( def. "1.0" )` - Modifier of the health the activator receives from runners.
 - `dr_activator_healthbar ( def. "1" )` - If enabled, the activator health will be displayed on screen.
 - `dr_speed_modifier ( def. "0.0" )` - Maximum speed modifier for all classes, in HU/s.

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1137,6 +1137,31 @@
 		}
 	}
 	
+	// Engineer - PDA [Slot 3]
+	"25"	// Construction PDA
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"building cost reduction"
+				"value"	"10.0"
+			}
+		}
+	}
+	
+	"737"	// Construction PDA (Renamed/Strange)
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"building cost reduction"
+				"value"	"10.0"
+			}
+		}
+	}
+	
 	// Medic - Primary [Slot 0]
 	"305"	// Crusader's Crossbow
 	{

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -712,6 +712,17 @@
 			}
 		}
 	}
+	"131"	// Chargin' Targe
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"charge recharge rate increased"
+				"value"	"0.0"
+			}
+		}
+	}
 	"207"	// Stickybomb Launcher (Renamed/Strange)
 	{
 		"attributes"
@@ -741,6 +752,17 @@
 			"1"
 			{
 				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"406"	// Splendid Screen
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"charge recharge rate increased"
 				"value"	"0.0"
 			}
 		}
@@ -840,6 +862,17 @@
 			"1"
 			{
 				"name"	"self dmg push force decreased"
+				"value"	"0.0"
+			}
+		}
+	}
+	"1144"	// Festive Chargin' Targe
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"charge recharge rate increased"
 				"value"	"0.0"
 			}
 		}
@@ -1579,6 +1612,16 @@
 		{
 			"1"
 			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"cloak consume rate increased"
+				"value"	"1.5"
+			}
+			"3"
+			{
 				"name"	"ReducedCloakFromAmmo"
 				"value"	"0.0"
 			}
@@ -1589,6 +1632,16 @@
 		"attributes"
 		{
 			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"cloak consume rate increased"
+				"value"	"1.5"
+			}
+			"3"
 			{
 				"name"	"ReducedCloakFromAmmo"
 				"value"	"0.0"
@@ -1601,6 +1654,16 @@
 		{
 			"1"
 			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"cloak consume rate increased"
+				"value"	"1.5"
+			}
+			"3"
+			{
 				"name"	"ReducedCloakFromAmmo"
 				"value"	"0.0"
 			}
@@ -1612,12 +1675,22 @@
 		{
 			"1"
 			{
-				"name"	"set cloak is movement based"
+				"name"	"mult cloak meter regen rate"
 				"value"	"0.0"
 			}
 			"2"
 			{
+				"name"	"cloak consume rate increased"
+				"value"	"1.5"
+			}
+			"3"
+			{
 				"name"	"ReducedCloakFromAmmo"
+				"value"	"0.0"
+			}
+			"4"
+			{
+				"name"	"set cloak is movement based"
 				"value"	"0.0"
 			}
 		}
@@ -1627,6 +1700,16 @@
 		"attributes"
 		{
 			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"cloak consume rate increased"
+				"value"	"1.5"
+			}
+			"3"
 			{
 				"name"	"ReducedCloakFromAmmo"
 				"value"	"0.0"
@@ -1638,6 +1721,16 @@
 		"attributes"
 		{
 			"1"
+			{
+				"name"	"mult cloak meter regen rate"
+				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"cloak consume rate increased"
+				"value"	"1.5"
+			}
+			"3"
 			{
 				"name"	"ReducedCloakFromAmmo"
 				"value"	"0.0"

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1670,12 +1670,4 @@
 			}
 		}
 	}
-	
-	// Action Items/Cosmetics [Slot 7-10]
-	"5869"	// Jungle Inferno ConTracker
-	{
-		// HACK: This item never passes through a SetTransmit hook due to an attached particle having EF_EDICT_ALWAYS set
-		// Find a way to make it not transmit instead of removing it outright
-		"remove"	"1"
-	}
 }

--- a/addons/sourcemod/gamedata/deathrun.txt
+++ b/addons/sourcemod/gamedata/deathrun.txt
@@ -14,13 +14,11 @@
 		{
 			"CTFPlayer::GetEquippedWearableForLoadoutSlot"
 			{
-				"library"	"server"
 				"linux"		"@_ZN9CTFPlayer33GetEquippedWearableForLoadoutSlotEi"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x2A\x8B\xC1\x53\x56\x33\xF6\x89\x45\xF8\x8B\x88\x2A\x2A\x2A\x2A\x57\x89\x4D\xFC"
 			}
 			"CTFPlayer::TeamFortress_CalculateMaxSpeed"
 			{
-				"library"	"server"
 				"linux"		"@_ZNK9CTFPlayer30TeamFortress_CalculateMaxSpeedEb"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x18\x83\x3D\x2A\x2A\x2A\x2A\x00\x56\x8B\xF1\x75\x2A\xD9\xEE\x5E\x8B\xE5\x5D\xC2\x04\x00\x8B\x86"
 			}

--- a/addons/sourcemod/gamedata/deathrun.txt
+++ b/addons/sourcemod/gamedata/deathrun.txt
@@ -24,6 +24,11 @@
 				"linux"		"@_ZNK9CTFPlayer30TeamFortress_CalculateMaxSpeedEb"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x18\x83\x3D\x2A\x2A\x2A\x2A\x00\x56\x8B\xF1\x75\x2A\xD9\xEE\x5E\x8B\xE5\x5D\xC2\x04\x00\x8B\x86"
 			}
+			"CTFPlayer::GetMaxHealthForBuffing"
+			{
+				"linux"		"@_ZN9CTFPlayer22GetMaxHealthForBuffingEv"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x24\x53\x56\x57\x8B\xF9\xFF\xB7\x10\x21\x00\x00"
+			}
 		}
 		"Functions"
 		{
@@ -74,6 +79,13 @@
 						"type"	"bool"
 					}
 				}
+			}
+			"CTFPlayer::GetMaxHealthForBuffing"
+			{
+				"signature"	"CTFPlayer::GetMaxHealthForBuffing"
+				"callconv"	"thiscall"
+				"return"	"int"
+				"this"		"entity"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -105,7 +105,7 @@ ConVar dr_runner_glow;
 ConVar dr_activator_count;
 ConVar dr_activator_health_modifier;
 ConVar dr_activator_healthbar;
-ConVar dr_scout_speed_penalty;
+ConVar dr_speed_modifier[view_as<int>(TFClassType)];
 
 ArrayList g_CurrentActivators;
 

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -102,8 +102,9 @@ ConVar dr_queue_points;
 ConVar dr_allow_thirdperson;
 ConVar dr_chattips_interval;
 ConVar dr_runner_glow;
-ConVar dr_num_activators;
+ConVar dr_activator_count;
 ConVar dr_activator_health_modifier;
+ConVar dr_activator_healthbar;
 ConVar dr_scout_speed_penalty;
 
 ArrayList g_CurrentActivators;
@@ -201,6 +202,35 @@ public void OnClientDisconnect(int client)
 		g_CurrentActivators.Erase(index);
 	
 	DRPlayer(client).Reset();
+}
+
+public void OnGameFrame()
+{
+	int monsterResource = FindEntityByClassname(MaxClients + 1, "monster_resource");
+	if (monsterResource != -1)
+	{
+		if (dr_activator_healthbar.BoolValue)
+		{
+			int maxhealth, health;
+			
+			for (int client = 1; client <= MaxClients; client++)
+			{
+				if (IsClientInGame(client) && DRPlayer(client).IsActivator())
+				{
+					if (IsPlayerAlive(client))
+						health += GetEntProp(client, Prop_Send, "m_iHealth");
+					
+					maxhealth += TF2_GetMaxHealth(client);
+				}
+			}
+			
+			SetEntProp(monsterResource, Prop_Send, "m_iBossHealthPercentageByte", Min(RoundFloat(float(health) / float(maxhealth) * 255), 255));
+		}
+		else
+		{
+			SetEntProp(monsterResource, Prop_Send, "m_iBossHealthPercentageByte", 0);
+		}
+	}
 }
 
 public void OnEntityCreated(int entity, const char[] classname)

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -104,6 +104,8 @@ ConVar dr_allow_thirdperson;
 ConVar dr_chattips_interval;
 ConVar dr_runner_glow;
 ConVar dr_num_activators;
+ConVar dr_activator_health_base;
+ConVar dr_activator_health_modifier;
 ConVar dr_scout_speed_penalty;
 
 ArrayList g_CurrentActivators;
@@ -201,8 +203,6 @@ public void OnClientDisconnect(int client)
 		g_CurrentActivators.Erase(index);
 	
 	DRPlayer(client).Reset();
-	
-	UpdateActivatorHealth(-TF2_GetMaxHealth(client), false);
 }
 
 public void OnEntityCreated(int entity, const char[] classname)
@@ -291,22 +291,3 @@ static Action OnClientSoundPlayed(int clients[MAXPLAYERS], int &numClients, int 
 	return action;
 }
 
-void UpdateActivatorHealth(int value, bool refill)
-{
-	for (int i = 0; i < g_CurrentActivators.Length; i++)
-	{
-		int activator = g_CurrentActivators.Get(i);
-		if (IsClientInGame(activator))
-		{
-			Address address = TF2Attrib_GetByName(activator, "max health additive bonus");
-			if (address != Address_Null)
-			{
-				TF2Attrib_SetValue(address, FloatMax(TF2Attrib_GetValue(address) + float(value) / dr_num_activators.FloatValue, 0.0));
-				TF2Attrib_ClearCache(activator);
-				
-				if (refill)
-					SetEntityHealth(activator, GetEntProp(activator, Prop_Send, "m_iHealth") + value / dr_num_activators.IntValue);
-			}
-		}
-	}
-}

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -31,6 +31,9 @@
 #define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
 #define PLUGIN_VERSION		"1.5.0"
+#define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
+
+#define PLUGIN_TAG	"[{primary}" ... PLUGIN_NAME ... "{default}]"
 
 #define GAMESOUND_EXPLOSION		"MVM.BombExplodes"
 
@@ -127,7 +130,7 @@ public Plugin pluginInfo =  {
 	author = PLUGIN_AUTHOR, 
 	description = "Team Fortress 2 Deathrun", 
 	version = PLUGIN_VERSION, 
-	url = "https://github.com/Mikusch/deathrun"
+	url = PLUGIN_URL
 };
 
 public void OnPluginStart()
@@ -135,8 +138,8 @@ public void OnPluginStart()
 	LoadTranslations("common.phrases.txt");
 	LoadTranslations("deathrun.phrases.txt");
 	
-	CAddColor("primary", 0x4285F4);
-	CAddColor("secondary", 0xAA66CC);
+	CAddColor("primary", 0x4B69FF);
+	CAddColor("secondary", 0xFF9F4B);
 	CAddColor("positive", 0x00C851);
 	CAddColor("negative", 0xFF4444);
 	

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -224,7 +224,23 @@ public void OnGameFrame()
 				}
 			}
 			
-			SetEntProp(monsterResource, Prop_Send, "m_iBossHealthPercentageByte", Min(RoundFloat(float(health) / float(maxhealth) * 255), 255));
+			static float nextHealthBarHideTime;
+			static int oldHealthBarValue;
+			
+			int healthBarValue = Min(RoundFloat(float(health) / float(maxhealth) * 255), 255);
+			
+			if (GameRules_GetRoundState() == RoundState_Preround || (oldHealthBarValue != 0 && oldHealthBarValue != healthBarValue))
+			{
+				nextHealthBarHideTime = GetGameTime() + 10.0;
+				oldHealthBarValue = healthBarValue;
+				
+				SetEntProp(monsterResource, Prop_Send, "m_iBossHealthPercentageByte", healthBarValue);
+			}
+			else if (nextHealthBarHideTime <= GetGameTime())
+			{
+				//Hide the health bar if it hasn't changed in a while
+				SetEntProp(monsterResource, Prop_Send, "m_iBossHealthPercentageByte", 0);
+			}
 		}
 	}
 }

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -30,8 +30,7 @@
 
 #define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
-#define PLUGIN_VERSION		"1.4.2"
-#define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
+#define PLUGIN_VERSION		"1.5.0"
 
 #define GAMESOUND_EXPLOSION		"MVM.BombExplodes"
 
@@ -99,7 +98,6 @@ char g_PreferenceNames[][] =  {
 };
 
 ConVar dr_queue_points;
-ConVar dr_allow_thirdperson;
 ConVar dr_chattips_interval;
 ConVar dr_runner_glow;
 ConVar dr_activator_count;
@@ -129,7 +127,7 @@ public Plugin pluginInfo =  {
 	author = PLUGIN_AUTHOR, 
 	description = "Team Fortress 2 Deathrun", 
 	version = PLUGIN_VERSION, 
-	url = PLUGIN_URL
+	url = "https://github.com/Mikusch/deathrun"
 };
 
 public void OnPluginStart()
@@ -139,8 +137,8 @@ public void OnPluginStart()
 	
 	CAddColor("primary", 0x4285F4);
 	CAddColor("secondary", 0xAA66CC);
-	CAddColor("success", 0x00C851);
-	CAddColor("danger", 0xFF4444);
+	CAddColor("positive", 0x00C851);
+	CAddColor("negative", 0xFF4444);
 	
 	AddNormalSoundHook(OnSoundPlayed);
 	

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -33,7 +33,7 @@
 #define PLUGIN_VERSION		"1.5.0"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
-#define PLUGIN_TAG	"[{primary}" ... PLUGIN_NAME ... "{default}]"
+#define PLUGIN_TAG		"[{primary}" ... PLUGIN_NAME ... "{default}]"
 
 #define GAMESOUND_EXPLOSION		"MVM.BombExplodes"
 

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -30,7 +30,6 @@
 
 #define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
-#define PLUGIN_DESCRIPTION	"Team Fortress 2 Deathrun"
 #define PLUGIN_VERSION		"1.4.2"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
@@ -127,7 +126,7 @@ ArrayList g_CurrentActivators;
 public Plugin pluginInfo =  {
 	name = PLUGIN_NAME, 
 	author = PLUGIN_AUTHOR, 
-	description = PLUGIN_DESCRIPTION, 
+	description = "Team Fortress 2 Deathrun", 
 	version = PLUGIN_VERSION, 
 	url = PLUGIN_URL
 };
@@ -289,4 +288,3 @@ static Action OnClientSoundPlayed(int clients[MAXPLAYERS], int &numClients, int 
 	
 	return action;
 }
-

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -104,7 +104,6 @@ ConVar dr_allow_thirdperson;
 ConVar dr_chattips_interval;
 ConVar dr_runner_glow;
 ConVar dr_num_activators;
-ConVar dr_activator_health_base;
 ConVar dr_activator_health_modifier;
 ConVar dr_scout_speed_penalty;
 

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -206,10 +206,10 @@ public void OnClientDisconnect(int client)
 
 public void OnGameFrame()
 {
-	int monsterResource = FindEntityByClassname(MaxClients + 1, "monster_resource");
-	if (monsterResource != -1)
+	if (dr_activator_healthbar.BoolValue)
 	{
-		if (dr_activator_healthbar.BoolValue)
+		int monsterResource = FindEntityByClassname(MaxClients + 1, "monster_resource");
+		if (monsterResource != -1)
 		{
 			int maxhealth, health;
 			
@@ -225,10 +225,6 @@ public void OnGameFrame()
 			}
 			
 			SetEntProp(monsterResource, Prop_Send, "m_iBossHealthPercentageByte", Min(RoundFloat(float(health) / float(maxhealth) * 255), 255));
-		}
-		else
-		{
-			SetEntProp(monsterResource, Prop_Send, "m_iBossHealthPercentageByte", 0);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -242,6 +242,12 @@ void Config_Apply(int client)
 					ItemEntPropConfig entprop;
 					if (config.entprops.GetArray(i, entprop, sizeof(entprop)) > 0)
 					{
+						if (!HasEntProp(item, entprop.type, entprop.name))
+						{
+							LogError("Invalid entity property: %s", entprop.name);
+							continue;
+						}
+						
 						switch (entprop.fieldType)
 						{
 							case PropField_Integer:

--- a/addons/sourcemod/scripting/deathrun/console.sp
+++ b/addons/sourcemod/scripting/deathrun/console.sp
@@ -31,6 +31,7 @@ void Console_Init()
 	
 	RegConsoleCmd("dr", ConCmd_DeathrunMenu);
 	RegConsoleCmd("deathrun", ConCmd_DeathrunMenu);
+	RegConsoleCmd2("menu", ConCmd_DeathrunMenu);
 	
 	RegConsoleCmd2("next", ConCmd_QueueMenu);
 	RegConsoleCmd2("queue", ConCmd_QueueMenu);

--- a/addons/sourcemod/scripting/deathrun/console.sp
+++ b/addons/sourcemod/scripting/deathrun/console.sp
@@ -45,7 +45,6 @@ void Console_Init()
 	RegAdminCmd2("addqueue", ConCmd_AddQueuePoints, ADMFLAG_CHANGEMAP);
 	RegAdminCmd2("addqueuepoints", ConCmd_AddQueuePoints, ADMFLAG_CHANGEMAP);
 	
-	AddCommandListener(CommandListener_Build, "build");
 	AddCommandListener(CommandListener_JoinTeam, "jointeam");
 	AddCommandListener(CommandListener_JoinTeam, "autoteam");
 	AddCommandListener(CommandListener_JoinTeam, "spectate");
@@ -190,12 +189,6 @@ public Action ConCmd_AddQueuePoints(int client, int args)
 		CShowActivity2(client, "{default}" ... PLUGIN_TAG ... " ", "%t", "Command_AddQueuePoints_Added", amount, "_s", target_name);
 	}
 	
-	return Plugin_Handled;
-}
-
-public Action CommandListener_Build(int client, const char[] command, int argc)
-{
-	//Disallow building
 	return Plugin_Handled;
 }
 

--- a/addons/sourcemod/scripting/deathrun/console.sp
+++ b/addons/sourcemod/scripting/deathrun/console.sp
@@ -32,11 +32,6 @@ void Console_Init()
 	RegConsoleCmd2("preferences", ConCmd_PreferencesMenu);
 	RegConsoleCmd2("settings", ConCmd_PreferencesMenu);
 	
-	RegConsoleCmd2("tp", ConCmd_ThirdPerson);
-	RegConsoleCmd2("thirdperson", ConCmd_ThirdPerson);
-	RegConsoleCmd2("fp", ConCmd_FirstPerson);
-	RegConsoleCmd2("firstperson", ConCmd_FirstPerson);
-	
 	RegConsoleCmd2("hide", ConCmd_HideTeammates);
 	RegConsoleCmd2("hideteammates", ConCmd_HideTeammates);
 	RegConsoleCmd2("hideplayers", ConCmd_HideTeammates);
@@ -90,58 +85,6 @@ public Action ConCmd_PreferencesMenu(int client, int args)
 	}
 	
 	Menus_DisplayPreferencesMenu(client);
-	return Plugin_Handled;
-}
-
-public Action ConCmd_ThirdPerson(int client, int args)
-{
-	if (client == 0)
-	{
-		ReplyToCommand(client, "%t", "Command is in-game only");
-		return Plugin_Handled;
-	}
-	
-	if (!dr_allow_thirdperson.BoolValue)
-	{
-		PrintMessage(client, "%t", "Command_Disabled");
-		return Plugin_Handled;
-	}
-	
-	SetVariantInt(true);
-	if (AcceptEntityInput(client, "SetForcedTauntCam"))
-	{
-		DRPlayer(client).InThirdPerson = true;
-		
-		if (!IsPlayerAlive(client) || TF2_IsPlayerInCondition(client, TFCond_Taunting))
-			PrintMessage(client, "%t", "Command_ThirdPerson_Enabled");
-	}
-	
-	return Plugin_Handled;
-}
-
-public Action ConCmd_FirstPerson(int client, int args)
-{
-	if (client == 0)
-	{
-		ReplyToCommand(client, "%t", "Command is in-game only");
-		return Plugin_Handled;
-	}
-	
-	if (!dr_allow_thirdperson.BoolValue)
-	{
-		PrintMessage(client, "%t", "Command_Disabled");
-		return Plugin_Handled;
-	}
-	
-	SetVariantInt(false);
-	if (AcceptEntityInput(client, "SetForcedTauntCam"))
-	{
-		DRPlayer(client).InThirdPerson = false;
-		
-		if (!IsPlayerAlive(client) || TF2_IsPlayerInCondition(client, TFCond_Taunting))
-			PrintMessage(client, "%t", "Command_ThirdPerson_Disabled");
-	}
-	
 	return Plugin_Handled;
 }
 

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -36,6 +36,8 @@ void ConVars_Init()
 	dr_chattips_interval = CreateConVar("dr_chattips_interval", "240", "Interval between helpful tips printed to chat, in seconds. Set to 0 to disable chat tips.");
 	dr_runner_glow = CreateConVar("dr_runner_glow", "0", "If enabled, runners will have a glowing outline.");
 	dr_num_activators = CreateConVar("dr_num_activators", "1", "Amount of activators chosen at the start of a round.", _, true, 1.0, true, float(MaxClients - 1));
+	dr_activator_health_base = CreateConVar("dr_activator_health_base", "100", "Base health of the activator.", _, true, 1.0);
+	dr_activator_health_modifier = CreateConVar("dr_activator_health_modifier", "1.0", "Modifier of the health the activator receives from runners.", _, true, 0.0);
 	dr_scout_speed_penalty = CreateConVar("dr_scout_speed_penalty", "80.0", "Max speed penalty for Scouts, in HU/s.");
 	
 	dr_allow_thirdperson.AddChangeHook(ConVarChanged_AllowThirdPerson);

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -36,7 +36,6 @@ void ConVars_Init()
 	dr_chattips_interval = CreateConVar("dr_chattips_interval", "240", "Interval between helpful tips printed to chat, in seconds. Set to 0 to disable chat tips.");
 	dr_runner_glow = CreateConVar("dr_runner_glow", "0", "If enabled, runners will have a glowing outline.");
 	dr_num_activators = CreateConVar("dr_num_activators", "1", "Amount of activators chosen at the start of a round.", _, true, 1.0, true, float(MaxClients - 1));
-	dr_activator_health_base = CreateConVar("dr_activator_health_base", "100", "Base health of the activator.", _, true, 1.0);
 	dr_activator_health_modifier = CreateConVar("dr_activator_health_modifier", "1.0", "Modifier of the health the activator receives from runners.", _, true, 0.0);
 	dr_scout_speed_penalty = CreateConVar("dr_scout_speed_penalty", "80.0", "Max speed penalty for Scouts, in HU/s.");
 	

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -38,7 +38,16 @@ void ConVars_Init()
 	dr_activator_count = CreateConVar("dr_activator_count", "1", "Amount of activators chosen at the start of a round.", _, true, 1.0, true, float(MaxClients - 1));
 	dr_activator_health_modifier = CreateConVar("dr_activator_health_modifier", "1.0", "Modifier of the health the activator receives from runners.", _, true, 0.0);
 	dr_activator_healthbar = CreateConVar("dr_activator_healthbar", "1", "If enabled, the activator health will be displayed on screen.");
-	dr_scout_speed_penalty = CreateConVar("dr_scout_speed_penalty", "80.0", "Max speed penalty for Scouts, in HU/s.");
+	dr_speed_modifier[0] = CreateConVar("dr_speed_modifier", "0.0", "Maximum speed modifier for all classes, in HU/s.");
+	dr_speed_modifier[1] = CreateConVar("dr_speed_modifier_scout", "-80.0", "Maximum speed modifier for Scout, in HU/s.");
+	dr_speed_modifier[2] = CreateConVar("dr_speed_modifier_sniper", "0.0", "Maximum speed modifier for Sniper, in HU/s.");
+	dr_speed_modifier[3] = CreateConVar("dr_speed_modifier_soldier", "0.0", "Maximum speed modifier for Soldier, in HU/s.");
+	dr_speed_modifier[4] = CreateConVar("dr_speed_modifier_demoman", "0.0", "Maximum speed modifier for Demoman, in HU/s.");
+	dr_speed_modifier[5] = CreateConVar("dr_speed_modifier_medic", "0.0", "Maximum speed modifier for Medic, in HU/s.");
+	dr_speed_modifier[6] = CreateConVar("dr_speed_modifier_heavy", "0.0", "Maximum speed modifier for Heavy, in HU/s.");
+	dr_speed_modifier[7] = CreateConVar("dr_speed_modifier_pyro", "0.0", "Maximum speed modifier for Pyro, in HU/s.");
+	dr_speed_modifier[8] = CreateConVar("dr_speed_modifier_spy", "0.0", "Maximum speed modifier for Spy, in HU/s.");
+	dr_speed_modifier[9] = CreateConVar("dr_speed_modifier_engineer", "0.0", "Maximum speed modifier for Engineer, in HU/s.");
 	
 	dr_allow_thirdperson.AddChangeHook(ConVarChanged_AllowThirdPerson);
 	dr_chattips_interval.AddChangeHook(ConVarChanged_ChatTipsInterval);

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -35,8 +35,9 @@ void ConVars_Init()
 	dr_allow_thirdperson = CreateConVar("dr_allow_thirdperson", "1", "If enabled, players may toggle thirdperson. Set to 0 if you use other thirdperson plugins that may conflict.");
 	dr_chattips_interval = CreateConVar("dr_chattips_interval", "240", "Interval between helpful tips printed to chat, in seconds. Set to 0 to disable chat tips.");
 	dr_runner_glow = CreateConVar("dr_runner_glow", "0", "If enabled, runners will have a glowing outline.");
-	dr_num_activators = CreateConVar("dr_num_activators", "1", "Amount of activators chosen at the start of a round.", _, true, 1.0, true, float(MaxClients - 1));
+	dr_activator_count = CreateConVar("dr_activator_count", "1", "Amount of activators chosen at the start of a round.", _, true, 1.0, true, float(MaxClients - 1));
 	dr_activator_health_modifier = CreateConVar("dr_activator_health_modifier", "1.0", "Modifier of the health the activator receives from runners.", _, true, 0.0);
+	dr_activator_healthbar = CreateConVar("dr_activator_healthbar", "1", "If enabled, the activator health will be displayed on screen.");
 	dr_scout_speed_penalty = CreateConVar("dr_scout_speed_penalty", "80.0", "Max speed penalty for Scouts, in HU/s.");
 	
 	dr_allow_thirdperson.AddChangeHook(ConVarChanged_AllowThirdPerson);

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -58,11 +58,8 @@ void ConVars_Init()
 	ConVars_Add("mp_teams_unbalance_limit", "0");
 	ConVars_Add("tf_arena_first_blood", "0");
 	ConVars_Add("tf_arena_use_queue", "0");
-	ConVars_Add("tf_avoidteammates_pushaway", "0");
+	ConVars_Add("tf_avoidteammates_pushaway", "0", false);
 	ConVars_Add("tf_scout_air_dash_count", "0", false);
-	ConVars_Add("tf_spy_cloak_regen_rate", "0.0", false);
-	ConVars_Add("tf_demoman_charge_regen_rate", "0.0", false);
-	ConVars_Add("tf_spy_cloak_consume_rate", "25.0", false);
 }
 
 void ConVars_Add(const char[] name, const char[] value, bool enforce = true)

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -32,7 +32,6 @@ void ConVars_Init()
 	CreateConVar("dr_version", PLUGIN_VERSION, PLUGIN_NAME..." version", FCVAR_SPONLY | FCVAR_REPLICATED | FCVAR_NOTIFY | FCVAR_DONTRECORD);
 	
 	dr_queue_points = CreateConVar("dr_queue_points", "15", "Amount of queue points awarded to runners at the end of each round.", _, true, 1.0);
-	dr_allow_thirdperson = CreateConVar("dr_allow_thirdperson", "1", "If enabled, players may toggle thirdperson. Set to 0 if you use other thirdperson plugins that may conflict.");
 	dr_chattips_interval = CreateConVar("dr_chattips_interval", "240", "Interval between helpful tips printed to chat, in seconds. Set to 0 to disable chat tips.");
 	dr_runner_glow = CreateConVar("dr_runner_glow", "0", "If enabled, runners will have a glowing outline.");
 	dr_activator_count = CreateConVar("dr_activator_count", "1", "Amount of activators chosen at the start of a round.", _, true, 1.0, true, float(MaxClients - 1));
@@ -49,7 +48,6 @@ void ConVars_Init()
 	dr_speed_modifier[8] = CreateConVar("dr_speed_modifier_spy", "0.0", "Maximum speed modifier for Spy, in HU/s.");
 	dr_speed_modifier[9] = CreateConVar("dr_speed_modifier_engineer", "0.0", "Maximum speed modifier for Engineer, in HU/s.");
 	
-	dr_allow_thirdperson.AddChangeHook(ConVarChanged_AllowThirdPerson);
 	dr_chattips_interval.AddChangeHook(ConVarChanged_ChatTipsInterval);
 	dr_runner_glow.AddChangeHook(ConVarChanged_RunnerGlow);
 	dr_activator_healthbar.AddChangeHook(ConVarChanged_ActivatorHealthBar);
@@ -116,23 +114,6 @@ public void ConVarChanged_GameConVar(ConVar convar, const char[] oldValue, const
 		
 		if (!StrEqual(newValue, info.value))
 			info.convar.SetString(info.value);
-	}
-}
-
-public void ConVarChanged_AllowThirdPerson(ConVar convar, const char[] oldValue, const char[] newValue)
-{
-	if (!StringToInt(newValue))
-	{
-		for (int client = 1; client <= MaxClients; client++)
-		{
-			if (IsClientInGame(client) && DRPlayer(client).InThirdPerson)
-			{
-				DRPlayer(client).InThirdPerson = false;
-				SetVariantInt(0);
-				AcceptEntityInput(client, "SetForcedTauntCam");
-				PrintMessage(client, "%t", "Thirdperson_ForceDisable");
-			}
-		}
 	}
 }
 

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -43,6 +43,7 @@ void ConVars_Init()
 	dr_allow_thirdperson.AddChangeHook(ConVarChanged_AllowThirdPerson);
 	dr_chattips_interval.AddChangeHook(ConVarChanged_ChatTipsInterval);
 	dr_runner_glow.AddChangeHook(ConVarChanged_RunnerGlow);
+	dr_activator_healthbar.AddChangeHook(ConVarChanged_ActivatorHealthBar);
 	
 	g_GameConVars = new ArrayList(sizeof(ConVarInfo));
 	
@@ -128,7 +129,7 @@ public void ConVarChanged_AllowThirdPerson(ConVar convar, const char[] oldValue,
 
 public void ConVarChanged_ChatTipsInterval(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	Timers_CreateChatTipTimer(convar.FloatValue);
+	Timers_CreateChatTipTimer(StringToFloat(newValue));
 }
 
 public void ConVarChanged_RunnerGlow(ConVar convar, const char[] oldValue, const char[] newValue)
@@ -137,5 +138,15 @@ public void ConVarChanged_RunnerGlow(ConVar convar, const char[] oldValue, const
 	{
 		if (IsClientInGame(client) && !DRPlayer(client).IsActivator())
 			SetEntProp(client, Prop_Send, "m_bGlowEnabled", StringToInt(newValue));
+	}
+}
+
+public void ConVarChanged_ActivatorHealthBar(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	if (!StringToInt(newValue))
+	{
+		int monsterResource = FindEntityByClassname(MaxClients + 1, "monster_resource");
+		if (monsterResource != -1)
+			SetEntProp(monsterResource, Prop_Send, "m_iBossHealthPercentageByte", 0);
 	}
 }

--- a/addons/sourcemod/scripting/deathrun/dhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/dhooks.sp
@@ -89,7 +89,7 @@ public MRESReturn DHookCallback_CalculateMaxSpeed_Post(int client, DHookReturn r
 	if (IsClientInGame(client) && TF2_GetPlayerClass(client) == TFClass_Scout)
 	{
 		float speed = ret.Value;
-		ret.Value = FloatMax(speed - dr_scout_speed_penalty.FloatValue, 1.0);
+		ret.Value = Max(speed - dr_scout_speed_penalty.FloatValue, 1.0);
 		return MRES_Supercede;
 	}
 	

--- a/addons/sourcemod/scripting/deathrun/dhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/dhooks.sp
@@ -75,8 +75,8 @@ public MRESReturn DHook_SetWinningTeam_Pre(DHookParam param)
 		
 		EmitGameSoundToAll(GAMESOUND_EXPLOSION);
 		
-		param.Set(1, TFTeam_Activators); //team
-		param.Set(2, WINREASON_TIMELIMIT); //iWinReason
+		param.Set(1, TFTeam_Activators);	//team
+		param.Set(2, WINREASON_TIMELIMIT);	//iWinReason
 		return MRES_ChangedOverride;
 	}
 	

--- a/addons/sourcemod/scripting/deathrun/dhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/dhooks.sp
@@ -85,12 +85,18 @@ public MRESReturn DHook_SetWinningTeam_Pre(DHookParam param)
 
 public MRESReturn DHookCallback_CalculateMaxSpeed_Post(int client, DHookReturn ret)
 {
-	//We don't want speedy scouts
-	if (IsClientInGame(client) && TF2_GetPlayerClass(client) == TFClass_Scout)
+	if (IsClientInGame(client))
 	{
-		float speed = ret.Value;
-		ret.Value = Max(speed - dr_scout_speed_penalty.FloatValue, 1.0);
-		return MRES_Supercede;
+		//Modify player speed based on their class
+		TFClassType class = TF2_GetPlayerClass(client);
+		if (class != TFClass_Unknown)
+		{
+			float speed = ret.Value;
+			float modifier = dr_speed_modifier[0].FloatValue + dr_speed_modifier[class].FloatValue;
+			ret.Value = Max(speed + modifier, 1.0);
+			
+			return MRES_Supercede;
+		}
 	}
 	
 	return MRES_Ignored;

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -28,25 +28,12 @@ public Action EventHook_ArenaRoundStart(Event event, const char[] name, bool don
 {
 	int numActivators;
 	
-	//Calculate max health to grant to activators
-	int maxHealth;
-	for (int client = 1; client <= MaxClients; client++)
-	{
-		if (IsClientInGame(client) && TF2_GetClientTeam(client) == TFTeam_Runners)
-			maxHealth += TF2_GetMaxHealth(client);
-	}
-	
 	//Iterate all chosen activators and check if they are still in-game
 	for (int i = 0; i < g_CurrentActivators.Length; i++)
 	{
 		int activator = g_CurrentActivators.Get(i);
 		if (IsClientInGame(activator))
-		{
-			TF2Attrib_SetByName(activator, "max health additive bonus", float(maxHealth) / dr_num_activators.FloatValue);
-			SetEntityHealth(activator, TF2_GetMaxHealth(activator) + maxHealth / dr_num_activators.IntValue);
-			
 			numActivators++;
-		}
 	}
 	
 	if (numActivators > 1)	//Multiple activators

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -97,8 +97,6 @@ public Action EventHook_PlayerDeath_Pre(Event event, const char[] name, bool don
 	
 	if (GameRules_GetRoundState() == RoundState_Stalemate && !DRPlayer(victim).IsActivator())
 	{
-		UpdateActivatorHealth(-TF2_GetMaxHealth(victim), false);
-		
 		//Rewrite death event to credit activator
 		if (g_CurrentActivators.Length == 1)
 		{
@@ -117,10 +115,6 @@ public Action EventHook_PostInventoryApplication(Event event, const char[] name,
 	int client = GetClientOfUserId(userid);
 	
 	Config_Apply(client);
-	
-	//If this is a latespawn, give the activator health
-	if (GameRules_GetRoundState() == RoundState_Stalemate && !DRPlayer(client).IsActivator())
-		CreateTimer(0.2, Timer_UpdateActivatorHealth, userid);
 	
 	if (DRPlayer(client).InThirdPerson)
 		CreateTimer(0.2, Timer_SetThirdPerson, userid);
@@ -231,11 +225,6 @@ public void RequestFrameCallback_VerifyTeam(int userid)
 			}
 		}
 	}
-}
-
-public Action Timer_UpdateActivatorHealth(Handle timer, int userid)
-{
-	UpdateActivatorHealth(TF2_GetMaxHealth(GetClientOfUserId(userid)), true);
 }
 
 public Action Timer_SetThirdPerson(Handle timer, int userid)

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -43,15 +43,15 @@ public Action EventHook_ArenaRoundStart(Event event, const char[] name, bool don
 			if (IsClientInGame(client))
 			{
 				if (DRPlayer(client).IsActivator())
-					PrintMessage(client, "%t", "RoundStart_MultipleActivators_Activator");
+					CPrintToChat(client, PLUGIN_TAG ... " %t", "RoundStart_MultipleActivators_Activator");
 				else
-					PrintMessage(client, "%t", "RoundStart_MultipleActivators_Runners");
+					CPrintToChat(client, PLUGIN_TAG ... " %t", "RoundStart_MultipleActivators_Runners");
 			}
 		}
 	}
 	else if (numActivators < 1)	//No activators
 	{
-		PrintMessageToAll("%t", "RoundStart_Activator_Disconnected", FindConVar("mp_bonusroundtime").IntValue);
+		CPrintToChatAll(PLUGIN_TAG ... " %t", "RoundStart_Activator_Disconnected", FindConVar("mp_bonusroundtime").IntValue);
 	}
 	else	//One activator
 	{
@@ -64,9 +64,9 @@ public Action EventHook_ArenaRoundStart(Event event, const char[] name, bool don
 			if (IsClientInGame(client))
 			{
 				if (client == activator)
-					PrintMessage(client, "%t", "RoundStart_NewActivator_Activator");
+					CPrintToChat(client, PLUGIN_TAG ... " %t", "RoundStart_NewActivator_Activator");
 				else
-					PrintMessage(client, "%t", "RoundStart_NewActivator_Runners", activatorName);
+					CPrintToChat(client, PLUGIN_TAG ... " %t", "RoundStart_NewActivator_Runners", activatorName);
 			}
 		}
 	}
@@ -179,18 +179,15 @@ public Action EventHook_TeamplayRoundWin(Event event, const char[] name, bool do
 	
 	for (int client = 1; client <= MaxClients; client++)
 	{
-		DRPlayer player = DRPlayer(client);
 		if (IsClientInGame(client))
 		{
 			if (team == TFTeam_Activators)
-				PrintMessage(client, "%t", "RoundWin_Activator");
+				CPrintToChat(client, PLUGIN_TAG ... " %t", "RoundWin_Activator");
 			else if (team == TFTeam_Runners)
-				PrintMessage(client, "%t", "RoundWin_Runners");
+				CPrintToChat(client, PLUGIN_TAG ... " %t", "RoundWin_Runners");
 			
-			if (player.IsActivator())
-				TF2Attrib_RemoveByName(client, "max health additive bonus");
-			else if (TF2_GetClientTeam(client) != TFTeam_Spectator)
-				Queue_AddPoints(client, dr_queue_points.IntValue);
+			if (TF2_GetClientTeam(client) == TFTeam_Runners)
+				Queue_AwardPoints(client, dr_queue_points.IntValue);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -103,6 +103,14 @@ public Action EventHook_PostInventoryApplication(Event event, const char[] name,
 	
 	Config_Apply(client);
 	
+	for (int slot = 0; slot <= ItemSlot_Misc2; slot++)
+	{
+		//Some items always transmit, breaking our "hide players" feature
+		int item = TF2_GetItemInSlot(client, slot);
+		if (IsValidEntity(item))
+			SetEdictFlags(item, (GetEdictFlags(item) & ~FL_EDICT_ALWAYS | FL_EDICT_PVSCHECK));
+	}
+	
 	if (DRPlayer(client).InThirdPerson)
 		CreateTimer(0.2, Timer_SetThirdPerson, userid);
 	

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -103,14 +103,6 @@ public Action EventHook_PostInventoryApplication(Event event, const char[] name,
 	
 	Config_Apply(client);
 	
-	for (int slot = 0; slot <= ItemSlot_Misc2; slot++)
-	{
-		//Some items always transmit, breaking our "hide players" feature
-		int item = TF2_GetItemInSlot(client, slot);
-		if (IsValidEntity(item))
-			SetEdictFlags(item, (GetEdictFlags(item) & ~FL_EDICT_ALWAYS | FL_EDICT_PVSCHECK));
-	}
-	
 	if (DRPlayer(client).InThirdPerson)
 		CreateTimer(0.2, Timer_SetThirdPerson, userid);
 	

--- a/addons/sourcemod/scripting/deathrun/menus.sp
+++ b/addons/sourcemod/scripting/deathrun/menus.sp
@@ -23,7 +23,7 @@ void Menus_DisplayMainMenu(int client)
 {
 	Menu menu = new Menu(MenuHandler_MainMenu, MenuAction_Select | MenuAction_End | MenuAction_DrawItem | MenuAction_DisplayItem);
 	
-	menu.SetTitle("%T", "Menu_Main_Title", client, PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_AUTHOR);
+	menu.SetTitle("%T", "Menu_Main_Title", client, PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_AUTHOR, PLUGIN_URL);
 	
 	menu.AddItem(INFO_QUEUE, "Menu_Main_Queue");
 	menu.AddItem(INFO_PREFERENCES, "Menu_Main_Preferences");
@@ -165,9 +165,9 @@ public int MenuHandler_PreferencesMenu(Menu menu, MenuAction action, int param1,
 			Format(name, sizeof(name), "%T", g_PreferenceNames[i], param1);
 			
 			if (player.HasPreference(preference))
-				PrintMessage(param1, "%t", "Preferences_Enabled", name);
+				CPrintToChat(param1, PLUGIN_TAG ... " %t", "Preferences_Enabled", name);
 			else
-				PrintMessage(param1, "%t", "Preferences_Disabled", name);
+				CPrintToChat(param1, PLUGIN_TAG ... " %t", "Preferences_Disabled", name);
 			
 			Menus_DisplayPreferencesMenu(param1);
 		}

--- a/addons/sourcemod/scripting/deathrun/menus.sp
+++ b/addons/sourcemod/scripting/deathrun/menus.sp
@@ -111,7 +111,7 @@ void Menus_DisplayQueueMenu(int client)
 			char display[MAX_NAME_LENGTH + 8];
 			Format(display, sizeof(display), "%N (%d)", queueClient, queuePoints);
 			
-			menu.AddItem(NULL_STRING, display, ITEMDRAW_DISABLED);
+			menu.AddItem(NULL_STRING, display, client == queueClient ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED);
 		}
 		
 		menu.Display(client, MENU_TIME_FOREVER);

--- a/addons/sourcemod/scripting/deathrun/menus.sp
+++ b/addons/sourcemod/scripting/deathrun/menus.sp
@@ -17,18 +17,16 @@
 
 #define INFO_QUEUE			"queue"
 #define INFO_PREFERENCES	"preferences"
-#define INFO_THIRDPERSON	"thirdperson"
 #define INFO_HIDETEAMMATES	"hideteammates"
 
 void Menus_DisplayMainMenu(int client)
 {
 	Menu menu = new Menu(MenuHandler_MainMenu, MenuAction_Select | MenuAction_End | MenuAction_DrawItem | MenuAction_DisplayItem);
 	
-	menu.SetTitle("%T", "Menu_Main_Title", client, PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_AUTHOR, PLUGIN_URL);
+	menu.SetTitle("%T", "Menu_Main_Title", client, PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_AUTHOR);
 	
 	menu.AddItem(INFO_QUEUE, "Menu_Main_Queue");
 	menu.AddItem(INFO_PREFERENCES, "Menu_Main_Preferences");
-	menu.AddItem(INFO_THIRDPERSON, "Menu_Main_ThirdPerson");
 	menu.AddItem(INFO_HIDETEAMMATES, "Menu_Main_HideTeammates");
 	
 	menu.Display(client, MENU_TIME_FOREVER);
@@ -51,11 +49,6 @@ public int MenuHandler_MainMenu(Menu menu, MenuAction action, int param1, int pa
 			{
 				Menus_DisplayPreferencesMenu(param1);
 			}
-			else if (StrEqual(info, INFO_THIRDPERSON))
-			{
-				FakeClientCommand(param1, DRPlayer(param1).InThirdPerson ? "dr_firstperson" : "dr_thirdperson");
-				Menus_DisplayMainMenu(param1);
-			}
 			else if (StrEqual(info, INFO_HIDETEAMMATES))
 			{
 				FakeClientCommand(param1, "dr_hideteammates");
@@ -65,17 +58,6 @@ public int MenuHandler_MainMenu(Menu menu, MenuAction action, int param1, int pa
 		case MenuAction_End:
 		{
 			delete menu;
-		}
-		case MenuAction_DrawItem:
-		{
-			int style;
-			char info[64];
-			menu.GetItem(param2, info, sizeof(info), style);
-			
-			if (StrEqual(info, INFO_THIRDPERSON) && !dr_allow_thirdperson.BoolValue)
-				return ITEMDRAW_DISABLED;
-			
-			return style;
 		}
 		case MenuAction_DisplayItem:
 		{
@@ -207,9 +189,9 @@ public int MenuHandler_PreferencesMenu(Menu menu, MenuAction action, int param1,
 			PreferenceType preference = view_as<PreferenceType>(RoundToNearest(Pow(2.0, float(i))));
 			
 			if (DRPlayer(param1).HasPreference(preference))
-				Format(display, sizeof(display), "■ %T", g_PreferenceNames[i], param1);
+				Format(display, sizeof(display), "☑ %T", g_PreferenceNames[i], param1);
 			else
-				Format(display, sizeof(display), "□ %T", g_PreferenceNames[i], param1);
+				Format(display, sizeof(display), "☐ %T", g_PreferenceNames[i], param1);
 			
 			return RedrawMenuItem(display);
 		}

--- a/addons/sourcemod/scripting/deathrun/queue.sp
+++ b/addons/sourcemod/scripting/deathrun/queue.sp
@@ -41,7 +41,7 @@ void Queue_SetNextActivatorsFromQueue()
 	
 	ArrayList queue = Queue_GetQueueList();
 	
-	for (int i = 0; i < dr_num_activators.IntValue; i++)
+	for (int i = 0; i < dr_activator_count.IntValue; i++)
 	{
 		int activator;
 		

--- a/addons/sourcemod/scripting/deathrun/queue.sp
+++ b/addons/sourcemod/scripting/deathrun/queue.sp
@@ -24,7 +24,7 @@ ArrayList Queue_GetQueueList()
 	{
 		if (Queue_IsClientAllowed(client))
 		{
-			queue.Set(length, DRPlayer(client).QueuePoints, 0); //block 0 gets sorted
+			queue.Set(length, DRPlayer(client).QueuePoints, 0);	//block 0 gets sorted
 			queue.Set(length, client, 1);
 			length++;
 		}
@@ -65,7 +65,7 @@ void Queue_SetNextActivatorsFromQueue()
 			}
 			
 			activator = clients[GetRandomInt(0, numClients - 1)];
-			PrintMessage(activator, "%t", "Queue_ChosenAsRandomActivator");
+			CPrintToChat(activator, PLUGIN_TAG ... " %t", "Queue_ChosenAsRandomActivator");
 		}
 		
 		g_CurrentActivators.Push(activator);
@@ -75,25 +75,32 @@ void Queue_SetNextActivatorsFromQueue()
 	delete queue;
 }
 
-void Queue_AddPoints(int client, int points)
+void Queue_AwardPoints(int client, int points)
 {
 	DRPlayer player = DRPlayer(client);
 	
 	if (player.QueuePoints == -1)
 	{
-		PrintMessage(client, "%t", "Queue_NoPointsAwarded_NotLoaded");
+		CPrintToChat(client, PLUGIN_TAG ... " %t", "Queue_NoPointsAwarded_NotLoaded");
 		return;
 	}
 	else if (DRPlayer(client).HasPreference(Preference_DontBeActivator))
 	{
-		PrintMessage(client, "%t", "Queue_NoPointsAwarded_Preferences");
+		CPrintToChat(client, PLUGIN_TAG ... " %t", "Queue_NoPointsAwarded_Preferences");
 		return;
 	}
 	
 	player.QueuePoints += points;
 	Cookies_SaveQueue(client, player.QueuePoints);
 	
-	PrintMessage(client, "%t", "Queue_PointsAwarded", dr_queue_points.IntValue, player.QueuePoints);
+	CPrintToChat(client, PLUGIN_TAG ... " %t", "Queue_PointsAwarded", dr_queue_points.IntValue, player.QueuePoints);
+}
+
+void Queue_AddPoints(int client, int points)
+{
+	DRPlayer player = DRPlayer(client);
+	player.QueuePoints += points;
+	Cookies_SaveQueue(client, player.QueuePoints);
 }
 
 void Queue_SetPoints(int client, int points)

--- a/addons/sourcemod/scripting/deathrun/queue.sp
+++ b/addons/sourcemod/scripting/deathrun/queue.sp
@@ -112,15 +112,8 @@ void Queue_SetPoints(int client, int points)
 
 bool Queue_IsClientAllowed(int client)
 {
-	if (IsValidClient(client)
-		 && TF2_GetClientTeam(client) > TFTeam_Spectator	//Is the client not in spectator team?
-		 && DRPlayer(client).QueuePoints != -1	//Does the client have their queue points loaded?
-		 && !DRPlayer(client).HasPreference(Preference_DontBeActivator))	//Does the client want to be the activator?
-	{
-		return true;
-	}
-	else
-	{
-		return false;
-	}
+	return IsValidClient(client)
+	 && TF2_GetClientTeam(client) > TFTeam_Spectator	//Is the client not in spectator team?
+	 && DRPlayer(client).QueuePoints != -1	//Does the client have their queue points loaded?
+	 && !DRPlayer(client).HasPreference(Preference_DontBeActivator);	//Does the client want to be the activator?
 }

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -44,7 +44,7 @@ void SDKHooks_OnEntityCreated(int entity, const char[] classname)
 		}
 	}
 	
-	if (StrContains(classname, "obj_") != -1)
+	if (strncmp(classname, "obj_", 4) == 0)
 	{
 		RemoveAlwaysTransmit(entity);
 		SDKHook(entity, SDKHook_SetTransmit, SDKHookCB_ObjectSetTransmit);
@@ -55,7 +55,7 @@ void SDKHooks_OnEntityCreated(int entity, const char[] classname)
 		SDKHook(entity, SDKHook_SetTransmit, SDKHookCB_DroppedWeaponSetTransmit);
 	}
 	
-	if (StrContains(classname, "tf_projectile") != -1)
+	if (strncmp(classname, "tf_projectile_", 14) == 0)
 	{
 		RemoveAlwaysTransmit(entity);
 		SDKHook(entity, SDKHook_SetTransmit, HasEntProp(entity, Prop_Send, "m_hThrower") ? SDKHookCB_ThrownEntitySetTransmit : SDKHookCB_OwnedEntitySetTransmit);

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -18,6 +18,7 @@
 static char g_OwnerEntityList[][] =  {
 	"env_sniperdot", 
 	"halloween_souls_pack", 
+	"light_dynamic", 
 	"info_particle_system", 
 	"item_healthkit", 
 	"tf_ammo_pack", 

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -17,7 +17,6 @@
 
 static char g_OwnerEntityList[][] =  {
 	"env_sniperdot", 
-	"gib", 
 	"halloween_souls_pack", 
 	"item_healthkit", 
 	"tf_ammo_pack", 
@@ -51,20 +50,15 @@ void SDKHooks_OnEntityCreated(int entity, const char[] classname)
 		SDKHook(entity, SDKHook_SetTransmit, SDKHookCB_ObjectSetTransmit);
 	}
 	
+	if (StrEqual(classname, "tf_dropped_weapon"))
+	{
+		SDKHook(entity, SDKHook_SetTransmit, SDKHookCB_DroppedWeaponSetTransmit);
+	}
+	
 	if (StrContains(classname, "tf_projectile") != -1)
 	{
 		RemoveAlwaysTransmit(entity);
 		SDKHook(entity, SDKHook_SetTransmit, HasEntProp(entity, Prop_Send, "m_hThrower") ? SDKHookCB_ThrownEntitySetTransmit : SDKHookCB_OwnedEntitySetTransmit);
-	}
-	
-	if (StrEqual(classname, "tf_ragdoll"))
-	{
-		SDKHook(entity, SDKHook_SetTransmit, SDKHookCB_RagdollSetTransmit);
-	}
-	
-	if (StrEqual(classname, "tf_dropped_weapon"))
-	{
-		SDKHook(entity, SDKHook_SetTransmit, SDKHookCB_DroppedWeaponSetTransmit);
 	}
 }
 
@@ -120,30 +114,6 @@ public Action SDKHookCB_ThrownEntitySetTransmit(int entity, int client)
 	return Plugin_Continue;
 }
 
-public Action SDKHookCB_OwnedEntitySetTransmit(int entity, int client)
-{
-	RemoveAlwaysTransmit(entity);
-	
-	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
-	if (IsValidClient(owner) && DRPlayer(client).CanHideClient(owner))
-		return Plugin_Handled;
-	
-	return Plugin_Continue;
-}
-
-public Action SDKHookCB_RagdollSetTransmit(int entity, int client)
-{
-	int playerIndex = GetEntProp(entity, Prop_Send, "m_iPlayerIndex");
-	if (IsValidClient(playerIndex) && DRPlayer(client).CanHideClient(playerIndex))
-	{
-		//We need to remove the flag here instead because otherwise no ragdolls get created for anyone
-		RemoveAlwaysTransmit(entity);
-		return Plugin_Handled;
-	}
-	
-	return Plugin_Continue;
-}
-
 public Action SDKHookCB_DroppedWeaponSetTransmit(int entity, int client)
 {
 	int accountID = GetEntProp(entity, Prop_Send, "m_iAccountID");
@@ -152,6 +122,17 @@ public Action SDKHookCB_DroppedWeaponSetTransmit(int entity, int client)
 		if (IsClientConnected(i) && GetSteamAccountID(i, false) == accountID && DRPlayer(client).CanHideClient(i))
 			return Plugin_Handled;
 	}
+	
+	return Plugin_Continue;
+}
+
+public Action SDKHookCB_OwnedEntitySetTransmit(int entity, int client)
+{
+	RemoveAlwaysTransmit(entity);
+	
+	int owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
+	if (IsValidClient(owner) && DRPlayer(client).CanHideClient(owner))
+		return Plugin_Handled;
 	
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -45,6 +45,12 @@ void SDKHooks_OnEntityCreated(int entity, const char[] classname)
 		}
 	}
 	
+	if (StrContains(classname, "obj_") != -1)
+	{
+		RemoveAlwaysTransmit(entity);
+		SDKHook(entity, SDKHook_SetTransmit, SDKHookCB_ObjectSetTransmit);
+	}
+	
 	if (StrContains(classname, "tf_projectile") != -1)
 	{
 		RemoveAlwaysTransmit(entity);
@@ -91,6 +97,15 @@ public Action SDKHookCB_ClientGetMaxHealth(int entity, int &maxhealth)
 		maxhealth = health;
 		return Plugin_Changed;
 	}
+	
+	return Plugin_Continue;
+}
+
+public Action SDKHookCB_ObjectSetTransmit(int entity, int client)
+{
+	int builder = GetEntPropEnt(entity, Prop_Send, "m_hBuilder");
+	if (IsValidClient(builder) && DRPlayer(client).CanHideClient(builder))
+		return Plugin_Handled;
 	
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -88,7 +88,7 @@ public Action SDKHookCB_ClientGetMaxHealth(int client, int &maxhealth)
 				maxhealth += RoundFloat(TF2_GetMaxHealth(i) * dr_activator_health_modifier.FloatValue);
 		}
 		
-		maxhealth /= dr_num_activators.IntValue;
+		maxhealth /= dr_activator_count.IntValue;
 		
 		//Refill the activator's health during preround
 		if (GameRules_GetRoundState() == RoundState_Preround)

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -88,6 +88,8 @@ public Action SDKHookCB_ClientGetMaxHealth(int client, int &maxhealth)
 				maxhealth += RoundFloat(TF2_GetMaxHealth(i) * dr_activator_health_modifier.FloatValue);
 		}
 		
+		maxhealth /= dr_num_activators.IntValue;
+		
 		//Refill the activator's health during preround
 		if (GameRules_GetRoundState() == RoundState_Preround)
 			SetEntityHealth(client, maxhealth);

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -125,7 +125,7 @@ public Action SDKHookCB_DroppedWeaponSetTransmit(int entity, int client)
 public Action SDKHookCB_VGUIScreenSetTransmit(int entity, int client)
 {
 	int obj = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity");
-	if (IsValidEntity(obj))
+	if (IsValidEntity(obj) && HasEntProp(obj, Prop_Send, "m_hBuilder"))
 	{
 		int builder = GetEntPropEnt(obj, Prop_Send, "m_hBuilder");
 		if (IsValidClient(builder) && DRPlayer(client).CanHideClient(builder))

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -18,6 +18,7 @@
 static char g_OwnerEntityList[][] =  {
 	"env_sniperdot", 
 	"halloween_souls_pack", 
+	"info_particle_system", 
 	"item_healthkit", 
 	"tf_ammo_pack", 
 	"tf_bonus_duck_pickup", 

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -30,7 +30,6 @@ static char g_OwnerEntityList[][] =  {
 void SDKHooks_OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_SetTransmit, SDKHookCB_ClientSetTransmit);
-	SDKHook(client, SDKHook_GetMaxHealth, SDKHookCB_ClientGetMaxHealth);
 }
 
 void SDKHooks_OnEntityCreated(int entity, const char[] classname)
@@ -85,28 +84,6 @@ public Action SDKHookCB_ClientSetTransmit(int entity, int client)
 			SetEdictFlags(disguiseWeapon, (GetEdictFlags(disguiseWeapon) & ~FL_EDICT_ALWAYS));
 		
 		return Plugin_Handled;
-	}
-	
-	return Plugin_Continue;
-}
-
-public Action SDKHookCB_ClientGetMaxHealth(int client, int &maxhealth)
-{
-	if (DRPlayer(client).IsActivator())
-	{
-		for (int i = 1; i <= MaxClients; i++)
-		{
-			if (client != i && IsValidClient(i) && IsPlayerAlive(i) && !DRPlayer(i).IsActivator())
-				maxhealth += RoundFloat(TF2_GetMaxHealth(i) * dr_activator_health_modifier.FloatValue);
-		}
-		
-		maxhealth /= dr_activator_count.IntValue;
-		
-		//Refill the activator's health during preround
-		if (GameRules_GetRoundState() == RoundState_Preround)
-			SetEntityHealth(client, maxhealth);
-		
-		return Plugin_Changed;
 	}
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/deathrun/sdkhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/sdkhooks.sp
@@ -78,23 +78,20 @@ public Action SDKHookCB_ClientSetTransmit(int entity, int client)
 	return Plugin_Continue;
 }
 
-public Action SDKHookCB_ClientGetMaxHealth(int entity, int &maxhealth)
+public Action SDKHookCB_ClientGetMaxHealth(int client, int &maxhealth)
 {
-	int health = dr_activator_health_base.IntValue;
-	
-	if (DRPlayer(entity).IsActivator())
+	if (DRPlayer(client).IsActivator())
 	{
-		for (int client = 1; client <= MaxClients; client++)
+		for (int i = 1; i <= MaxClients; i++)
 		{
-			if (entity != client && IsValidClient(client) && IsPlayerAlive(client) && !DRPlayer(client).IsActivator())
-				health += RoundFloat(TF2_GetMaxHealth(client) * dr_activator_health_modifier.FloatValue);
+			if (client != i && IsValidClient(i) && IsPlayerAlive(i) && !DRPlayer(i).IsActivator())
+				maxhealth += RoundFloat(TF2_GetMaxHealth(i) * dr_activator_health_modifier.FloatValue);
 		}
 		
 		//Refill the activator's health during preround
 		if (GameRules_GetRoundState() == RoundState_Preround)
-			SetEntProp(entity, Prop_Send, "m_iHealth", health);
+			SetEntityHealth(client, maxhealth);
 		
-		maxhealth = health;
 		return Plugin_Changed;
 	}
 	

--- a/addons/sourcemod/scripting/deathrun/stocks.sp
+++ b/addons/sourcemod/scripting/deathrun/stocks.sp
@@ -104,19 +104,3 @@ stock int GetAliveClientCount()
 	}
 	return count;
 }
-
-stock void PrintMessage(int client, const char[] format, any...)
-{
-	char message[MAX_BUFFER_LENGTH];
-	VFormat(message, sizeof(message), format, 3);
-	Format(message, sizeof(message), "[{primary}"...PLUGIN_NAME..."{default}] %s", message);
-	CPrintToChat(client, message);
-}
-
-stock void PrintMessageToAll(const char[] format, any...)
-{
-	char message[MAX_BUFFER_LENGTH];
-	VFormat(message, sizeof(message), format, 2);
-	Format(message, sizeof(message), "[{primary}"...PLUGIN_NAME..."{default}] %s", message);
-	CPrintToChatAll(message);
-}

--- a/addons/sourcemod/scripting/deathrun/stocks.sp
+++ b/addons/sourcemod/scripting/deathrun/stocks.sp
@@ -104,3 +104,42 @@ stock int GetAliveClientCount()
 	}
 	return count;
 }
+
+stock void CReplyToTargetError(int client, int reason)
+{
+	switch (reason)
+	{
+		case COMMAND_TARGET_NONE:
+		{
+			CReplyToCommand(client, PLUGIN_TAG ... " %t", "No matching client");
+		}
+		case COMMAND_TARGET_NOT_ALIVE:
+		{
+			CReplyToCommand(client, PLUGIN_TAG ... " %t", "Target must be alive");
+		}
+		case COMMAND_TARGET_NOT_DEAD:
+		{
+			CReplyToCommand(client, PLUGIN_TAG ... " %t", "Target must be dead");
+		}
+		case COMMAND_TARGET_NOT_IN_GAME:
+		{
+			CReplyToCommand(client, PLUGIN_TAG ... " %t", "Target is not in game");
+		}
+		case COMMAND_TARGET_IMMUNE:
+		{
+			CReplyToCommand(client, PLUGIN_TAG ... " %t", "Unable to target");
+		}
+		case COMMAND_TARGET_EMPTY_FILTER:
+		{
+			CReplyToCommand(client, PLUGIN_TAG ... " %t", "No matching clients");
+		}
+		case COMMAND_TARGET_NOT_HUMAN:
+		{
+			CReplyToCommand(client, PLUGIN_TAG ... " %t", "Cannot target bot");
+		}
+		case COMMAND_TARGET_AMBIGUOUS:
+		{
+			CReplyToCommand(client, PLUGIN_TAG ... " %t", "More than one client matched");
+		}
+	}
+}

--- a/addons/sourcemod/scripting/deathrun/stocks.sp
+++ b/addons/sourcemod/scripting/deathrun/stocks.sp
@@ -46,19 +46,14 @@ stock void StringToVector(const char[] buffer, float vec[3], float defvalue[3] =
 	vec[2] = StringToFloat(parts[2]);
 }
 
-stock float FloatMin(float a, float b)
+stock any Min(any a, any b)
 {
 	return (a < b) ? a : b;
 }
 
-stock float FloatMax(float a, float b)
+stock any Max(any a, any b)
 {
 	return (a > b) ? a : b;
-}
-
-stock float FloatClamp(float val, float min, float max)
-{
-	return FloatMax(min, FloatMin(max, val));
 }
 
 stock int TF2_GetItemInSlot(int client, int slot)
@@ -126,7 +121,7 @@ stock void PrintMessage(int client, const char[] format, any...)
 {
 	char message[MAX_BUFFER_LENGTH];
 	VFormat(message, sizeof(message), format, 3);
-	Format(message, sizeof(message), "[{primary}DR{default}] %s", message);
+	Format(message, sizeof(message), "[{primary}"...PLUGIN_NAME..."{default}] %s", message);
 	CPrintToChat(client, message);
 }
 
@@ -134,6 +129,6 @@ stock void PrintMessageToAll(const char[] format, any...)
 {
 	char message[MAX_BUFFER_LENGTH];
 	VFormat(message, sizeof(message), format, 2);
-	Format(message, sizeof(message), "[{primary}DR{default}] %s", message);
+	Format(message, sizeof(message), "[{primary}"...PLUGIN_NAME..."{default}] %s", message);
 	CPrintToChatAll(message);
 }

--- a/addons/sourcemod/scripting/deathrun/stocks.sp
+++ b/addons/sourcemod/scripting/deathrun/stocks.sp
@@ -94,18 +94,6 @@ stock void TF2_ChangeClientTeamAlive(int client, TFTeam team)
 	TF2_RespawnPlayer(client);
 }
 
-stock void RemoveAlwaysTransmit(int edict)
-{
-	//Function for allowing transmit hook for edicts set to always transmit
-	if (0 < edict <= 2048)
-	{
-		if (edict > MaxClients)
-			SetEdictFlags(edict, (GetEdictFlags(edict) & ~FL_EDICT_ALWAYS) | FL_EDICT_PVSCHECK);
-		else
-			SetEdictFlags(edict, (GetEdictFlags(edict) & ~FL_EDICT_ALWAYS));
-	}
-}
-
 stock int GetAliveClientCount()
 {
 	int count = 0;

--- a/addons/sourcemod/scripting/deathrun/timers.sp
+++ b/addons/sourcemod/scripting/deathrun/timers.sp
@@ -48,7 +48,7 @@ public Action Timer_PrintChatTip(Handle timer)
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client) && !DRPlayer(client).HasPreference(Preference_HideChatTips))
-			PrintMessage(client, "%t", tip);
+			CPrintToChat(client, PLUGIN_TAG ... " %t", tip);
 	}
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/translations/deathrun.phrases.txt
+++ b/addons/sourcemod/translations/deathrun.phrases.txt
@@ -12,6 +12,24 @@
 	{
 		"en"	"Your teammates are now {secondary}visible {default}to you."
 	}
+	"Command_AddQueuePoints_Usage"
+	{
+		"en"	"Usage: dr_addqueuepoints <#userid|name> [amount]"
+	}
+	"Command_AddQueuePoints_Added"
+	{
+		"#format"	"{1:d},{2:t}"
+		"en"		"Added {positive}{1} {default}queue point(s) to {2}."
+	}
+	
+	"Target_AllRunners"
+	{
+		"en"	"all runners"
+	}
+	"Target_AllActivators"
+	{
+		"en"	"all activators"
+	}
 	
 	"ChatTip_Deathrun"
 	{
@@ -72,12 +90,12 @@
 	"Preferences_Enabled"
 	{
 		"#format"	"{1:s}"
-		"en"		"You have positivefully {positive}enabled {default}the preference {secondary}{1}{default}."
+		"en"		"You have {positive}enabled {default}the preference {secondary}{1}{default}."
 	}
 	"Preferences_Disabled"
 	{
 		"#format"	"{1:s}"
-		"en"		"You have positivefully {negative}disabled {default}the preference {secondary}{1}{default}."
+		"en"		"You have {negative}disabled {default}the preference {secondary}{1}{default}."
 	}
 	
 	"Preference_DontBeActivator"
@@ -109,8 +127,8 @@
 	
 	"Menu_Main_Title"
 	{
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} ({2}) by {3}"
+		"#format"	"{1:s},{2:s},{3:s},{4:s}"
+		"en"		"{1} ({2}) by {3}\n{4}"
 	}
 	"Menu_Main_Queue"
 	{

--- a/addons/sourcemod/translations/deathrun.phrases.txt
+++ b/addons/sourcemod/translations/deathrun.phrases.txt
@@ -2,67 +2,76 @@
 {
 	"Command_Disabled"
 	{
-		"en"	"The server operator has disabled this command."
+		"en"		"The server operator has disabled this command."
 	}
 	"Command_HideTeammates_Enabled"
 	{
-		"en"	"Your teammates are now {secondary}invisible {default}to you."
+		"en"		"Your teammates are now {secondary}invisible {default}to you."
 	}
 	"Command_HideTeammates_Disabled"
 	{
-		"en"	"Your teammates are now {secondary}visible {default}to you."
+		"en"		"Your teammates are now {secondary}visible {default}to you."
 	}
 	"Command_AddQueuePoints_Usage"
 	{
-		"en"	"Usage: dr_addqueuepoints <#userid|name> [amount]"
+		"en"		"Usage: {secondary}dr_addqueue <#userid|name> <amount>"
 	}
-	"Command_AddQueuePoints_Added"
+	"Command_AddQueuePoints_Success"
 	{
 		"#format"	"{1:d},{2:t}"
-		"en"		"Added {positive}{1} {default}queue point(s) to {2}."
+		"en"		"Added {positive}{1} {default}queue point(s) to {secondary}{2}{default}."
+	}
+	"Command_SetQueuePoints_Usage"
+	{
+		"en"		"Usage: {secondary}dr_setqueue <#userid|name> <amount>"
+	}
+	"Command_SetQueuePoints_Success"
+	{
+		"#format"	"{1:t},{2:d}"
+		"en"		"Set the queue points of {secondary}{1} {default}to {secondary}{2}{default}."
 	}
 	
-	"Target_AllRunners"
+	"Target_RunnerTeam"
 	{
-		"en"	"all runners"
+		"en"		"Runner Team"
 	}
-	"Target_AllActivators"
+	"Target_ActivatorTeam"
 	{
-		"en"	"all activators"
+		"en"		"Activator Team"
 	}
 	
 	"ChatTip_Deathrun"
 	{
-		"en"	"{positive}PROTIP: {default}You can get an overview of all features and commands with {secondary}/deathrun{default} or {secondary}/dr{default}."
+		"en"		"{positive}PROTIP: {default}You can get an overview of all features and commands with {secondary}/deathrun{default} or {secondary}/dr{default}."
 	}
 	"ChatTip_HideTeammates"
 	{
-		"en"	"{positive}PROTIP: {default}Can't see in crowded areas? You can hide teammates blocking your sight with {secondary}/drhide{default}."
+		"en"		"{positive}PROTIP: {default}Can't see in crowded areas? You can hide teammates blocking your sight with {secondary}/drhide{default}."
 	}
 	"ChatTip_ActivatorWeapons"
 	{
-		"en"	"{positive}PROTIP: {default}As the {blue}Activator{default}, utilize ranged weapons from your loadout to hit traps from far away."
+		"en"		"{positive}PROTIP: {default}As the {blue}Activator{default}, utilize ranged weapons from your loadout to hit traps from far away."
 	}
 	"ChatTip_CheckQueue"
 	{
-		"en"	"{positive}PROTIP: {default}You can check the Activator queue with {secondary}/drnext{default}."
+		"en"		"{positive}PROTIP: {default}You can check the Activator queue with {secondary}/drnext{default}."
 	}
 	"ChatTip_DisableChatTips"
 	{
-		"en"	"{positive}PROTIP: {default}You can disable these chat tips by changing your user preferences with {secondary}/drsettings{default}."
+		"en"		"{positive}PROTIP: {default}You can disable these chat tips by changing your user preferences with {secondary}/drsettings{default}."
 	}
 	"ChatTip_DisableActivator"
 	{
-		"en"	"{positive}PROTIP: {default}Don't want to play as the {blue}Activator{default}? Change your user preferences with {secondary}/drsettings{default}."
+		"en"		"{positive}PROTIP: {default}Don't want to play as the {blue}Activator{default}? Change your user preferences with {secondary}/drsettings{default}."
 	}
 	
 	"RoundWin_Activator"
 	{
-		"en"	"The {blue}Activator {default}wins!"
+		"en"		"The {blue}Activator {default}wins!"
 	}
 	"RoundWin_Runners"
 	{
-		"en"	"The {red}Runners {default}win!"
+		"en"		"The {red}Runners {default}win!"
 	}
 	"RoundStart_NewActivator_Runners"
 	{
@@ -71,15 +80,15 @@
 	}
 	"RoundStart_NewActivator_Activator"
 	{
-		"en"	"You became the {blue}Activator{default}! Press the buttons to activate traps and emerge victorious over the enemy team!"
+		"en"		"You became the {blue}Activator{default}! Press the buttons to activate traps and emerge victorious over the enemy team!"
 	}
 	"RoundStart_MultipleActivators_Activator"
 	{
-		"en"	"You became an {blue}Activator{default}! Work together with your teammates to stop the Runners!"
+		"en"		"You became an {blue}Activator{default}! Work together with your teammates to stop the Runners!"
 	}
 	"RoundStart_MultipleActivators_Runners"
 	{
-		"en"	"Multiple players became the {blue}Activator{default}! Avoid getting killed by the traps and bring your team to victory!"
+		"en"		"Multiple players became the {blue}Activator{default}! Avoid getting killed by the traps and bring your team to victory!"
 	}
 	"RoundStart_Activator_Disconnected"
 	{
@@ -100,20 +109,20 @@
 	
 	"Preference_DontBeActivator"
 	{
-		"en"	"Don't select me as the Activator"
+		"en"		"Don't select me as the Activator"
 	}
 	"Preference_HideChatTips"
 	{
-		"en"	"Hide occasional chat tips"
+		"en"		"Hide occasional chat tips"
 	}
 	
 	"Queue_NoPointsAwarded_NotLoaded"
 	{
-		"en"	"You have not been awarded any queue points because the server failed to load your queue points."
+		"en"		"You have not been awarded any queue points because the server failed to load your queue points."
 	}
 	"Queue_NoPointsAwarded_Preferences"
 	{
-		"en"	"You have not been awarded any queue points based on your preferences."
+		"en"		"You have not been awarded any queue points based on your preferences."
 	}
 	"Queue_PointsAwarded"
 	{
@@ -122,7 +131,7 @@
 	}
 	"Queue_ChosenAsRandomActivator"
 	{
-		"en"	"You have been randomly chosen to become the {blue}Activator {default}because there were no other valid players in the server. Your queue points have not been consumed."
+		"en"		"You have been randomly chosen to become the {blue}Activator {default}because there were no other valid players in the server. Your queue points have not been consumed."
 	}
 	
 	"Menu_Main_Title"
@@ -132,19 +141,19 @@
 	}
 	"Menu_Main_Queue"
 	{
-		"en"	"View Activator Queue (/drnext)"
+		"en"		"View Activator Queue (/drnext)"
 	}
 	"Menu_Main_Preferences"
 	{
-		"en"	"Change User Preferences (/drsettings)"
+		"en"		"Change User Preferences (/drsettings)"
 	}
 	"Menu_Main_HideTeammates"
 	{
-		"en"	"Hide Teammates (/drhide)"
+		"en"		"Hide Teammates (/drhide)"
 	}
 	"Menu_Queue_Title"
 	{
-		"en"	"Activator Queue"
+		"en"		"Activator Queue"
 	}
 	"Menu_Queue_Title_QueuePoints"
 	{
@@ -153,14 +162,14 @@
 	}
 	"Menu_Queue_NotLoaded"
 	{
-		"en"	"Your queue points are still loading, please wait a moment."
+		"en"		"Your queue points are still loading, please wait a moment."
 	}
 	"Menu_Preferences_Title"
 	{
-		"en"	"User Preferences"
+		"en"		"User Preferences"
 	}
 	"Menu_Preferences_NotLoaded"
 	{
-		"en"	"Your preferences are still loading, please wait a moment."
+		"en"		"Your preferences are still loading, please wait a moment."
 	}
 }

--- a/addons/sourcemod/translations/deathrun.phrases.txt
+++ b/addons/sourcemod/translations/deathrun.phrases.txt
@@ -4,14 +4,6 @@
 	{
 		"en"	"The server operator has disabled this command."
 	}
-	"Command_ThirdPerson_Enabled"
-	{
-		"en"	"You have {success}enabled {default}the third-person camera."
-	}
-	"Command_ThirdPerson_Disabled"
-	{
-		"en"	"You have {danger}disabled {default}the third-person camera."
-	}
 	"Command_HideTeammates_Enabled"
 	{
 		"en"	"Your teammates are now {secondary}invisible {default}to you."
@@ -23,32 +15,27 @@
 	
 	"ChatTip_Deathrun"
 	{
-		"en"	"{success}PROTIP: {default}You can get an overview of all features and commands with {secondary}/deathrun{default} or {secondary}/dr{default}."
+		"en"	"{positive}PROTIP: {default}You can get an overview of all features and commands with {secondary}/deathrun{default} or {secondary}/dr{default}."
 	}
 	"ChatTip_HideTeammates"
 	{
-		"en"	"{success}PROTIP: {default}Can't see in crowded areas? You can hide teammates blocking your sight with {secondary}/drhide{default}."
+		"en"	"{positive}PROTIP: {default}Can't see in crowded areas? You can hide teammates blocking your sight with {secondary}/drhide{default}."
 	}
 	"ChatTip_ActivatorWeapons"
 	{
-		"en"	"{success}PROTIP: {default}As the {blue}Activator{default}, utilize ranged weapons from your loadout to hit traps from far away."
+		"en"	"{positive}PROTIP: {default}As the {blue}Activator{default}, utilize ranged weapons from your loadout to hit traps from far away."
 	}
 	"ChatTip_CheckQueue"
 	{
-		"en"	"{success}PROTIP: {default}You can check the Activator queue with {secondary}/drnext{default}."
+		"en"	"{positive}PROTIP: {default}You can check the Activator queue with {secondary}/drnext{default}."
 	}
 	"ChatTip_DisableChatTips"
 	{
-		"en"	"{success}PROTIP: {default}You can disable these chat tips by changing your user preferences with {secondary}/drsettings{default}."
+		"en"	"{positive}PROTIP: {default}You can disable these chat tips by changing your user preferences with {secondary}/drsettings{default}."
 	}
 	"ChatTip_DisableActivator"
 	{
-		"en"	"{success}PROTIP: {default}Don't want to play as the {blue}Activator{default}? Change your user preferences with {secondary}/drsettings{default}."
-	}
-	
-	"Thirdperson_ForceDisable"
-	{
-		"en"	"Your third-person camera has been disabled by the server operator."
+		"en"	"{positive}PROTIP: {default}Don't want to play as the {blue}Activator{default}? Change your user preferences with {secondary}/drsettings{default}."
 	}
 	
 	"RoundWin_Activator"
@@ -85,12 +72,12 @@
 	"Preferences_Enabled"
 	{
 		"#format"	"{1:s}"
-		"en"		"You have successfully {success}enabled {default}the preference {secondary}{1}{default}."
+		"en"		"You have positivefully {positive}enabled {default}the preference {secondary}{1}{default}."
 	}
 	"Preferences_Disabled"
 	{
 		"#format"	"{1:s}"
-		"en"		"You have successfully {danger}disabled {default}the preference {secondary}{1}{default}."
+		"en"		"You have positivefully {negative}disabled {default}the preference {secondary}{1}{default}."
 	}
 	
 	"Preference_DontBeActivator"
@@ -113,7 +100,7 @@
 	"Queue_PointsAwarded"
 	{
 		"#format"	"{1:d},{2:d}"
-		"en"		"You have been awarded {success}{1} {default}queue points (Total: {success}{2}{default})."
+		"en"		"You have been awarded {positive}{1} {default}queue points (Total: {positive}{2}{default})."
 	}
 	"Queue_ChosenAsRandomActivator"
 	{
@@ -122,7 +109,8 @@
 	
 	"Menu_Main_Title"
 	{
-		"en"	"Welcome to %s %s by %s!\n%s"
+		"#format"	"{1:s},{2:s},{3:s}"
+		"en"		"{1} ({2}) by {3}"
 	}
 	"Menu_Main_Queue"
 	{
@@ -131,10 +119,6 @@
 	"Menu_Main_Preferences"
 	{
 		"en"	"Change User Preferences (/drsettings)"
-	}
-	"Menu_Main_ThirdPerson"
-	{
-		"en"	"Toggle Third-Person Camera (/drthirdperson)"
 	}
 	"Menu_Main_HideTeammates"
 	{

--- a/addons/sourcemod/translations/ru/deathrun.phrases.txt
+++ b/addons/sourcemod/translations/ru/deathrun.phrases.txt
@@ -104,7 +104,7 @@
 	
 	"Menu_Main_Title"
 	{
-		"ru"	"{1} ({2}) от {3}"
+		"ru"	"{1} ({2}) от {3}\n{4}"
 	}
 	"Menu_Main_Queue"
 	{

--- a/addons/sourcemod/translations/ru/deathrun.phrases.txt
+++ b/addons/sourcemod/translations/ru/deathrun.phrases.txt
@@ -4,14 +4,6 @@
 	{
 		"ru"	"Оператор сервера отключил эту команду."
 	}
-	"Command_ThirdPerson_Enabled"
-	{
-		"ru"	"Вы {success}включили {default}камеру от третьего лица."
-	}
-	"Command_ThirdPerson_Disabled"
-	{
-		"ru"	"Вы {danger}отключили {default}камеру от третьего лица."
-	}
 	"Command_HideTeammates_Enabled"
 	{
 		"ru"	"Ваши товарищи по команде теперь {secondary}невидимы {default}для вас."
@@ -23,32 +15,27 @@
 	
 	"ChatTip_Deathrun"
 	{
-		"ru"	"{success}СОВЕТ: {default}Вы можете получить обзор всех функций и команд с помощью команды {secondary}/deathrun{default} или {secondary}/dr{default}."
+		"ru"	"{positive}СОВЕТ: {default}Вы можете получить обзор всех функций и команд с помощью команды {secondary}/deathrun{default} или {secondary}/dr{default}."
 	}
 	"ChatTip_HideTeammates"
 	{
-		"ru"	"{success}СОВЕТ: {default}Не видно в людных местах? Вы можете скрыть товарищей по команде, мешающим вам, с помощью команды {secondary}/drhide{default}."
+		"ru"	"{positive}СОВЕТ: {default}Не видно в людных местах? Вы можете скрыть товарищей по команде, мешающим вам, с помощью команды {secondary}/drhide{default}."
 	}
 	"ChatTip_ActivatorWeapons"
 	{
-		"ru"	"{success}СОВЕТ: {default}Играя за {blue}активатора{default}, используйте оружие дальнего боя из своего снаряжения, чтобы активировать ловушки издалека."
+		"ru"	"{positive}СОВЕТ: {default}Играя за {blue}активатора{default}, используйте оружие дальнего боя из своего снаряжения, чтобы активировать ловушки издалека."
 	}
 	"ChatTip_CheckQueue"
 	{
-		"ru"	"{success}СОВЕТ: {default}Вы можете проверить очередь активатора с помощью команды {secondary}/drnext{default}."
+		"ru"	"{positive}СОВЕТ: {default}Вы можете проверить очередь активатора с помощью команды {secondary}/drnext{default}."
 	}
 	"ChatTip_DisableChatTips"
 	{
-		"ru"	"{success}СОВЕТ: {default}Вы можете отключить эти подсказки в чате, изменив польз. настройки с помощью команды {secondary}/drsettings{default}."
+		"ru"	"{positive}СОВЕТ: {default}Вы можете отключить эти подсказки в чате, изменив польз. настройки с помощью команды {secondary}/drsettings{default}."
 	}
 	"ChatTip_DisableActivator"
 	{
-		"ru"	"{success}СОВЕТ: {default}Не хотите играть за {blue}активатора{default}? Измените свои польз. настройки с помощью команды {secondary}/drsettings{default}."
-	}
-	
-	"Thirdperson_ForceDisable"
-	{
-		"ru"	"Ваша камера от третьего лица была отключена оператором сервера."
+		"ru"	"{positive}СОВЕТ: {default}Не хотите играть за {blue}активатора{default}? Измените свои польз. настройки с помощью команды {secondary}/drsettings{default}."
 	}
 	
 	"RoundWin_Activator"
@@ -82,11 +69,11 @@
 	
 	"Preferences_Enabled"
 	{
-		"ru"		"Вы успешно {success}включили {default}настройку {secondary}{1}{default}."
+		"ru"		"Вы успешно {positive}включили {default}настройку {secondary}{1}{default}."
 	}
 	"Preferences_Disabled"
 	{
-		"ru"		"Вы успешно {danger}отключили {default}настройку {secondary}{1}{default}."
+		"ru"		"Вы успешно {negative}отключили {default}настройку {secondary}{1}{default}."
 	}
 	
 	"Preference_DontBeActivator"
@@ -108,7 +95,7 @@
 	}
 	"Queue_PointsAwarded"
 	{
-		"ru"		"Вы получили {success}{1} {default}очков очереди (Всего: {success}{2}{default})."
+		"ru"		"Вы получили {positive}{1} {default}очков очереди (Всего: {positive}{2}{default})."
 	}
 	"Queue_ChosenAsRandomActivator"
 	{
@@ -117,7 +104,7 @@
 	
 	"Menu_Main_Title"
 	{
-		"ru"	"Добро пожаловать в %s %s от %s!\n%s"
+		"ru"	"{1} ({2}) от {3}"
 	}
 	"Menu_Main_Queue"
 	{
@@ -126,10 +113,6 @@
 	"Menu_Main_Preferences"
 	{
 		"ru"	"Изменить настройки пользователя (/drsettings)"
-	}
-	"Menu_Main_ThirdPerson"
-	{
-		"ru"	"Переключить камеру от третьего лица (/drthirdperson)"
 	}
 	"Menu_Main_HideTeammates"
 	{

--- a/addons/sourcemod/translations/ru/deathrun.phrases.txt
+++ b/addons/sourcemod/translations/ru/deathrun.phrases.txt
@@ -48,7 +48,7 @@
 	}
 	"RoundStart_NewActivator_Runners"
 	{
-		"ru"		"{1} стал {blue}активатором{default}! Избегайте попадания в ловушки и приведите свою команду к победе!"
+		"ru"	"{1} стал {blue}активатором{default}! Избегайте попадания в ловушки и приведите свою команду к победе!"
 	}
 	"RoundStart_NewActivator_Activator"
 	{
@@ -64,16 +64,16 @@
 	}
 	"RoundStart_Activator_Disconnected"
 	{
-		"ru"		"{blue}Активатор {default}отключился! Раунд возобновится через {secondary}{1} {default}сек."
+		"ru"	"{blue}Активатор {default}отключился! Раунд возобновится через {secondary}{1} {default}сек."
 	}
 	
 	"Preferences_Enabled"
 	{
-		"ru"		"Вы успешно {positive}включили {default}настройку {secondary}{1}{default}."
+		"ru"	"Вы успешно {positive}включили {default}настройку {secondary}{1}{default}."
 	}
 	"Preferences_Disabled"
 	{
-		"ru"		"Вы успешно {negative}отключили {default}настройку {secondary}{1}{default}."
+		"ru"	"Вы успешно {negative}отключили {default}настройку {secondary}{1}{default}."
 	}
 	
 	"Preference_DontBeActivator"
@@ -95,7 +95,7 @@
 	}
 	"Queue_PointsAwarded"
 	{
-		"ru"		"Вы получили {positive}{1} {default}очков очереди (Всего: {positive}{2}{default})."
+		"ru"	"Вы получили {positive}{1} {default}очков очереди (Всего: {positive}{2}{default})."
 	}
 	"Queue_ChosenAsRandomActivator"
 	{
@@ -124,7 +124,7 @@
 	}
 	"Menu_Queue_Title_QueuePoints"
 	{
-		"ru"		"Ваши очки очереди: {1}"
+		"ru"	"Ваши очки очереди: {1}"
 	}
 	"Menu_Queue_NotLoaded"
 	{


### PR DESCRIPTION
# Release 1.5.0

### Improvements

- Massively improved "hide teammates" feature
    - Fixed Jungle Inferno Contracker not getting hidden properly
    - Fixed Heavies and players wearing Spellbooks not getting hidden on round restart
    - Added several other entities to the list of hidden entities (e.g. buildings built by a hidden player)
    - Better performance
- Improved activator health scaling
    - Activator health now changes whenever the health of a player changes
        - Fixes weird health numbers when a player dies with less or more health than they started into the round with (
          e.g. GRU heavies)
    - Maximum health now gets calculated during pre-round as well
    - Maximum health now updates between deaths as well (e.g. through GRU heavies)
- Several code improvements

### Additions

- Added activator health bar
    - Health bar will update every time the maximum health of the activator changes or the activator loses health
    - Hidden after 10 seconds of no activity
    - Every activator's health gets tracked in the health bar (in case of more than 1 activator)
- Added several new plugin convars to configure new features or improve customization of existing features
    - `dr_activator_count ( def. "1" )` - Amount of activators chosen at the start of a round.
        - Renamed from `dr_num_activators` to match the naming of the others
    - `dr_activator_health_modifier ( def. "1.0" )` - Modifier of the health the activator receives from runners.
    - `dr_activator_healthbar ( def. "1" )` - If enabled, the activator health will be displayed on screen.
    - `dr_speed_modifier ( def. "0.0" )` - Maximum speed modifier for all classes, in HU/s.
        - `dr_speed_modifier_scout ( def. "-80.0" )` - Maximum speed modifier for Scout, in HU/s.
            - Renamed from `dr_scout_speed_penalty` to match the naming of the others
        - `dr_speed_modifier_sniper ( def. "0.0" )` - Maximum speed modifier for Sniper, in HU/s.
        - `dr_speed_modifier_soldier ( def. "0.0" )` - Maximum speed modifier for Soldier, in HU/s.
        - `dr_speed_modifier_demoman ( def. "0.0" )` - Maximum speed modifier for Demoman, in HU/s.
        - `dr_speed_modifier_medic ( def. "0.0" )` - Maximum speed modifier for Medic, in HU/s.
        - `dr_speed_modifier_heavy ( def. "0.0" )` - Maximum speed modifier for Heavy, in HU/s.
        - `dr_speed_modifier_pyro ( def. "0.0" )` - Maximum speed modifier for Pyro, in HU/s.
        - `dr_speed_modifier_spy ( def. "0.0" )` - Maximum speed modifier for Spy, in HU/s.
        - `dr_speed_modifier_engineer ( def. "0.0" )` - Maximum speed modifier for Engineer, in HU/s.
- Added `dr_addqueuepoints` and `dr_setqueuepoints` admin commands
    - Can target multiple players
    - Can target the custom multi target groups `@runners` and `@activators`

### Removals

- Removed the built-in thirdperson feature
    - This feature was a remnant from older versions and was only implemented for the Redsun Over Paradise community
    - You can install [this plugin](https://forums.alliedmods.net/showthread.php?p=1694178) as a replacement

### Configuration Changes

It is recommended to update existing configurations to match these changes.

- Moved several TF2 convar changes to the default configuration file
    - The previous method proved to be too confusing since most server operators would expect weapon changes to reside
      in the `items.cfg` instead of being silently set by the plugin itself
    - cvar `tf_spy_cloak_regen_rate ( "0" )` -> attrib `mult cloak meter regen rate ( 0.0 )`
    - cvar `tf_spy_cloak_consume_rate ( "25" )` -> attrib `cloak consume rate increased ( 1.5 )`
    - cvar `tf_demoman_charge_regen_rate ( "0.0" )` -> attrib `charge recharge rate increased ( 0.0 )`
- Removed `build` command block and replaced it with PDA attribute `building cost reduction ( 10.0 )`
- Translation files: Replaced every usage of `{success}` with `{positive}` and every usage of `{danger}` with `{negative}`

Closes #1