### PR TITLE
Release 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Any item definition indexes specified in a map-specific item configuration will 
 - `dr_activator_healthbar ( def. "1" )` - If enabled, the activator health will be displayed on screen.
 - `dr_backstab_damage ( def. "750.0" )` - Damage dealt to the activator by backstabs. Set to 0 to let the game determine the damage.
 - `dr_speed_modifier ( def. "0.0" )` - Maximum speed modifier for all classes, in HU/s.
-    - `dr_speed_modifier_scout ( def. "-80.0" )` - Maximum speed modifier for Scout, in HU/s.
+    - `dr_speed_modifier_scout ( def. "0.0" )` - Maximum speed modifier for Scout, in HU/s.
     - `dr_speed_modifier_sniper ( def. "0.0" )` - Maximum speed modifier for Sniper, in HU/s.
     - `dr_speed_modifier_soldier ( def. "0.0" )` - Maximum speed modifier for Soldier, in HU/s.
     - `dr_speed_modifier_demoman ( def. "0.0" )` - Maximum speed modifier for Demoman, in HU/s.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Using entity properties (advanced):
 	{
 		"1"	// Makes the weapon start already detonated
 		{
+			"target"	"weapon"
 			"name"		"m_iDetonated"
 			"type"		"send"
 			"field_type"	"int"
@@ -82,6 +83,7 @@ These two methods may also be combined. For example, to give Medics a one-time u
 	{
 		"1"	// Sets the ÜberCharge level to 100%
 		{
+			"target"	"weapon"
 			"name"		"m_flChargeLevel"
 			"type"		"send"
 			"field_type"	"float"

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -768,13 +768,8 @@
 		{
 			"1"
 			{
-				"name"	"charge recharge rate increased"
-				"value"	"0.0"
-			}
-			"2"
-			{
 				"name"	"charge time decreased"
-				"value"	"-0.75"
+				"value"	"-1.5"
 			}
 		}
 	}
@@ -817,13 +812,8 @@
 		{
 			"1"
 			{
-				"name"	"charge recharge rate increased"
-				"value"	"0.0"
-			}
-			"2"
-			{
 				"name"	"charge time decreased"
-				"value"	"-0.75"
+				"value"	"-1.5"
 			}
 		}
 	}
@@ -932,13 +922,8 @@
 		{
 			"1"
 			{
-				"name"	"charge recharge rate increased"
-				"value"	"0.0"
-			}
-			"2"
-			{
 				"name"	"charge time decreased"
-				"value"	"-0.75"
+				"value"	"-1.5"
 			}
 		}
 	}
@@ -948,13 +933,8 @@
 		{
 			"1"
 			{
-				"name"	"charge recharge rate increased"
-				"value"	"0.0"
-			}
-			"2"
-			{
 				"name"	"charge time decreased"
-				"value"	"-0.75"
+				"value"	"-1.5"
 			}
 		}
 	}
@@ -1132,7 +1112,7 @@
 			"1"
 			{
 				"name"	"charge time increased"
-				"value"	"0.25"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1277,7 +1257,12 @@
 		{
 			"1"
 			{
-				"name"	"damage penalty"
+				"name"	"damage bonus"
+				"value"	"5.0"
+			}
+			"2"
+			{
+				"name"	"maxammo primary reduced"
 				"value"	"0.0"
 			}
 		}

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1,15 +1,6 @@
 // 
-// ITEM CONFIGURATION:
-//  This file is used to configure items, such as weapons and cosmetics.
-//
-// The key of each configuration entry is the item definition index of the item it applies to.
-//
-// Possible attributes:
-//  block_attack <bool>		- Whether the primary fire of this item should be blocked, if applicable
-//  block_attack2 <bool>	- Whether the secondary fire of this item should be blocked, if applicable
-//  remove <bool>			- Whether this item should be removed from the player on spawn
-//  attributes <list>		- List of item attributes
-//  entprops <list>			- List of entity properties
+// GLOBAL ITEM CONFIGURATION:
+//  Allows you to configure items, such as weapons and cosmetics.
 //
 "Items"
 {

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1107,17 +1107,6 @@
 			}
 		}
 	}
-	"404"	// Persian Persuader
-	{
-		"attributes"
-		{
-			"1"
-			{
-				"name"	"ammo gives charge"
-				"value"	"0.0"
-			}
-		}
-	}
 	
 	// Heavy - Secondary [Slot 1]
 	"42"	// Sandvich
@@ -1126,8 +1115,8 @@
 		{
 			"1"
 			{
-				"name"	"mult_item_meter_charge_rate"
-				"value"	"0.0"
+				"name"	"item_meter_charge_rate"
+				"value"	"-1.0"
 			}
 		}
 	}
@@ -1137,8 +1126,8 @@
 		{
 			"1"
 			{
-				"name"	"mult_item_meter_charge_rate"
-				"value"	"0.0"
+				"name"	"item_meter_charge_rate"
+				"value"	"-1.0"
 			}
 		}
 	}
@@ -1148,8 +1137,8 @@
 		{
 			"1"
 			{
-				"name"	"mult_item_meter_charge_rate"
-				"value"	"0.0"
+				"name"	"item_meter_charge_rate"
+				"value"	"-1.0"
 			}
 		}
 	}
@@ -1159,8 +1148,8 @@
 		{
 			"1"
 			{
-				"name"	"mult_item_meter_charge_rate"
-				"value"	"0.0"
+				"name"	"item_meter_charge_rate"
+				"value"	"-1.0"
 			}
 		}
 	}
@@ -1170,8 +1159,8 @@
 		{
 			"1"
 			{
-				"name"	"mult_item_meter_charge_rate"
-				"value"	"0.0"
+				"name"	"item_meter_charge_rate"
+				"value"	"-1.0"
 			}
 		}
 	}
@@ -1181,8 +1170,8 @@
 		{
 			"1"
 			{
-				"name"	"mult_item_meter_charge_rate"
-				"value"	"0.0"
+				"name"	"item_meter_charge_rate"
+				"value"	"-1.0"
 			}
 		}
 	}

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -803,6 +803,11 @@
 				"name"	"charge recharge rate increased"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"charge time decreased"
+				"value"	"-0.75"
+			}
 		}
 	}
 	"207"	// Stickybomb Launcher (Renamed/Strange)
@@ -846,6 +851,11 @@
 			{
 				"name"	"charge recharge rate increased"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"charge time decreased"
+				"value"	"-0.75"
 			}
 		}
 	}
@@ -957,6 +967,11 @@
 				"name"	"charge recharge rate increased"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"charge time decreased"
+				"value"	"-0.75"
+			}
 		}
 	}
 	"1144"	// Festive Chargin' Targe
@@ -967,6 +982,11 @@
 			{
 				"name"	"charge recharge rate increased"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"charge time decreased"
+				"value"	"-0.75"
 			}
 		}
 	}
@@ -1137,6 +1157,17 @@
 			}
 		}
 	}
+	"327"	// Claidheamh Mòr
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"charge time increased"
+				"value"	"0.25"
+			}
+		}
+	}
 	"404"	// Persian Persuader
 	{
 		"attributes"
@@ -1262,7 +1293,12 @@
 		{
 			"1"
 			{
-				"name"	"damage penalty"
+				"name"	"damage bonus"
+				"value"	"5.0"
+			}
+			"2"
+			{
+				"name"	"maxammo primary reduced"
 				"value"	"0.0"
 			}
 		}

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1281,7 +1281,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1297,7 +1308,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1313,7 +1335,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1329,7 +1362,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1345,7 +1389,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1361,7 +1416,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1377,7 +1443,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1393,7 +1470,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1409,7 +1497,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1425,7 +1524,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1441,7 +1551,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1457,7 +1578,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1473,7 +1605,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1489,7 +1632,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1505,7 +1659,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1521,7 +1686,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1537,7 +1713,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1553,7 +1740,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1569,7 +1767,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1585,7 +1794,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1601,7 +1821,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1617,7 +1848,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1633,7 +1875,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1649,7 +1902,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1665,7 +1929,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}
@@ -1681,7 +1956,18 @@
 			"2"
 			{
 				"name"	"ubercharge rate penalty"
-				"value"	"0.5"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"weapon"
+				"name"			"m_flChargeLevel"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"1.0"
 			}
 		}
 	}

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -49,38 +49,6 @@
 	}
 	
 	// Scout - Secondary [Slot 1]
-	"46"	// Bonk! Atomic Punch
-	{
-		"attributes"
-		{
-			"1"
-			{
-				"name"	"lunchbox adds minicrits"
-				"value"	"2.0"
-			}
-			"2"
-			{
-				"name"	"mod_mark_attacker_for_death"
-				"value"	"5.0"
-			}
-		}
-	}
-	"1145"	// Festive Bonk!
-	{
-		"attributes"
-		{
-			"1"
-			{
-				"name"	"lunchbox adds minicrits"
-				"value"	"2.0"
-			}
-			"2"
-			{
-				"name"	"mod_mark_attacker_for_death"
-				"value"	"5.0"
-			}
-		}
-	}
 	"449"	// Winger
 	{
 		"attributes"

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -580,7 +580,19 @@
 			"1"
 			{
 				"name"	"item_meter_charge_rate"
-				"value"	"-1.0"
+				"value"	"0.0"
+			}
+		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"player"
+				"name"			"m_flItemChargeMeter"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"0.0"
+				"element"		"1"
 			}
 		}
 	}
@@ -1116,7 +1128,7 @@
 			"1"
 			{
 				"name"	"item_meter_charge_rate"
-				"value"	"-1.0"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1127,7 +1139,7 @@
 			"1"
 			{
 				"name"	"item_meter_charge_rate"
-				"value"	"-1.0"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1138,7 +1150,7 @@
 			"1"
 			{
 				"name"	"item_meter_charge_rate"
-				"value"	"-1.0"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1149,7 +1161,7 @@
 			"1"
 			{
 				"name"	"item_meter_charge_rate"
-				"value"	"-1.0"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1160,7 +1172,7 @@
 			"1"
 			{
 				"name"	"item_meter_charge_rate"
-				"value"	"-1.0"
+				"value"	"0.0"
 			}
 		}
 	}
@@ -1171,7 +1183,7 @@
 			"1"
 			{
 				"name"	"item_meter_charge_rate"
-				"value"	"-1.0"
+				"value"	"0.0"
 			}
 		}
 	}

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -40,6 +40,17 @@
 	}
 	
 	// Scout - Secondary [Slot 1]
+	"46"	// Bonk! Atomic Punch
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"effect bar recharge rate increased"
+				"value"	"99999.9"
+			}
+		}
+	}
 	"449"	// Winger
 	{
 		"attributes"
@@ -48,6 +59,17 @@
 			{
 				"name"	"increased jump height from weapon"
 				"value"	"1.0"
+			}
+		}
+	}
+	"1145"	// Festive Bonk!
+	{
+		"attributes"
+		{
+			"1"
+			{
+				"name"	"effect bar recharge rate increased"
+				"value"	"99999.9"
 			}
 		}
 	}

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1250,6 +1250,18 @@
 				"value"	"0.0"
 			}
 		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"player"
+				"name"			"m_iAmmo"
+				"type"			"data"
+				"field_type"	"int"
+				"value"			"0"
+				"element"		"1"
+			}
+		}
 	}
 	"1079"	// Festive Crusader's Crossbow
 	{

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -151,7 +151,7 @@
 			}
 		}
 	}
-	"127"	// The Direct Hit
+	"127"	// Direct Hit
 	{
 		"attributes"
 		{
@@ -162,7 +162,7 @@
 			}
 		}
 	}
-	"228"	// The Black Box
+	"228"	// Black Box
 	{
 		"attributes"
 		{
@@ -184,7 +184,7 @@
 			}
 		}
 	}
-	"414"	// The Liberty Launcher
+	"414"	// Liberty Launcher
 	{
 		"attributes"
 		{
@@ -195,7 +195,7 @@
 			}
 		}
 	}
-	"441"	// The Cow Mangler 5000
+	"441"	// Cow Mangler 5000
 	{
 		"attributes"
 		{
@@ -206,7 +206,7 @@
 			}
 		}
 	}
-	"513"	// The Original
+	"513"	// Original
 	{
 		"attributes"
 		{
@@ -228,7 +228,7 @@
 			}
 		}
 	}
-	"730"	// The Beggar's Bazooka
+	"730"	// Beggar's Bazooka
 	{
 		"attributes"
 		{
@@ -338,7 +338,7 @@
 			}
 		}
 	}
-	"1104"	// The Air Strike
+	"1104"	// Air Strike
 	{
 		"attributes"
 		{
@@ -482,6 +482,64 @@
 		}
 	}
 	
+	// Soldier - Secondary [Slot 1]
+	"129"	// Buff Banner
+	{
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"player"
+				"name"			"m_flRageMeter"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"100.0"
+			}
+		}
+	}
+	"226"	// Battalion's Backup
+	{
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"player"
+				"name"			"m_flRageMeter"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"100.0"
+			}
+		}
+	}
+	"354"	// Concheror
+	{
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"player"
+				"name"			"m_flRageMeter"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"100.0"
+			}
+		}
+	}
+	"1001"	// Festive Buff Banner
+	{
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"player"
+				"name"			"m_flRageMeter"
+				"type"			"send"
+				"field_type"	"float"
+				"value"			"100.0"
+			}
+		}
+	}
+	
 	// Soldier - Melee [Slot 2]
 	"775"	// Escape Plan
 	{
@@ -501,7 +559,7 @@
 	}
 	
 	// Pyro - Secondary [Slot 1]
-	"39"	// The Flare Gun
+	"39"	// Flare Gun
 	{
 		"attributes"
 		{
@@ -512,7 +570,7 @@
 			}
 		}
 	}
-	"351"	// The Detonator
+	"351"	// Detonator
 	{
 		"attributes"
 		{
@@ -523,7 +581,7 @@
 			}
 		}
 	}
-	"595"	// The Manmelter
+	"595"	// Manmelter
 	{
 		"attributes"
 		{
@@ -534,7 +592,7 @@
 			}
 		}
 	}
-	"740"	// The Scorch Shot
+	"740"	// Scorch Shot
 	{
 		"attributes"
 		{
@@ -591,7 +649,7 @@
 			}
 		}
 	}
-	"308"	// The Loch-n-Load
+	"308"	// Loch-n-Load
 	{
 		"attributes"
 		{
@@ -602,7 +660,7 @@
 			}
 		}
 	}
-	"996"	// The Loose Cannon
+	"996"	// Loose Cannon
 	{
 		"attributes"
 		{
@@ -624,7 +682,7 @@
 			}
 		}
 	}
-	"1151"	// The Iron Bomber
+	"1151"	// Iron Bomber
 	{
 		"attributes"
 		{
@@ -758,7 +816,7 @@
 			}
 		}
 	}
-	"130"	// The Scottish Resistance
+	"130"	// Scottish Resistance
 	{
 		"attributes"
 		{
@@ -912,7 +970,7 @@
 			}
 		}
 	}
-	"1150"	// The Quickiebomb Launcher
+	"1150"	// Quickiebomb Launcher
 	{
 		"attributes"
 		{
@@ -1079,7 +1137,7 @@
 			}
 		}
 	}
-	"404"	// The Persian Persuader
+	"404"	// Persian Persuader
 	{
 		"attributes"
 		{
@@ -1098,18 +1156,18 @@
 		{
 			"1"
 			{
-				"name"	"lunchbox healing decreased"
+				"name"	"mult_item_meter_charge_rate"
 				"value"	"0.0"
 			}
 		}
 	}
-	"159"	// The Dalokohs Bar
+	"159"	// Dalokohs Bar
 	{
 		"attributes"
 		{
 			"1"
 			{
-				"name"	"lunchbox healing decreased"
+				"name"	"mult_item_meter_charge_rate"
 				"value"	"0.0"
 			}
 		}
@@ -1120,7 +1178,7 @@
 		{
 			"1"
 			{
-				"name"	"lunchbox healing decreased"
+				"name"	"mult_item_meter_charge_rate"
 				"value"	"0.0"
 			}
 		}
@@ -1131,7 +1189,7 @@
 		{
 			"1"
 			{
-				"name"	"lunchbox healing decreased"
+				"name"	"mult_item_meter_charge_rate"
 				"value"	"0.0"
 			}
 		}
@@ -1142,7 +1200,7 @@
 		{
 			"1"
 			{
-				"name"	"lunchbox healing decreased"
+				"name"	"mult_item_meter_charge_rate"
 				"value"	"0.0"
 			}
 		}
@@ -1153,7 +1211,7 @@
 		{
 			"1"
 			{
-				"name"	"lunchbox healing decreased"
+				"name"	"mult_item_meter_charge_rate"
 				"value"	"0.0"
 			}
 		}
@@ -1231,11 +1289,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"211"	// Medi Gun (Renamed/Strange)
@@ -1247,14 +1300,9 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
-	"35"	// The Kritzkrieg
+	"35"	// Kritzkrieg
 	{
 		"attributes"
 		{
@@ -1263,25 +1311,15 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
-	"411"	// The Quick-Fix
+	"411"	// Quick-Fix
 	{
 		"attributes"
 		{
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1295,11 +1333,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"796"	// Silver Botkiller Medi Gun Mk.I
@@ -1309,11 +1342,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1327,11 +1355,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"885"	// Rust Botkiller Medi Gun Mk.I
@@ -1341,11 +1364,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1359,11 +1377,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"903"	// Carbonado Botkiller Medi Gun Mk.I
@@ -1373,11 +1386,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1391,11 +1399,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"961"	// Silver Botkiller Medi Gun Mk.II
@@ -1405,11 +1408,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1423,25 +1421,15 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
-	"998"	// The Vaccinator
+	"998"	// Vaccinator
 	{
 		"attributes"
 		{
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1455,11 +1443,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"15010"	// Wrapped Reviver
@@ -1469,11 +1452,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1487,11 +1465,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"15039"	// Civil Servant
@@ -1501,11 +1474,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1519,11 +1487,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"15078"	// Wildwood
@@ -1533,11 +1496,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1551,11 +1509,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"15121"	// Dressed To Kill
@@ -1565,11 +1518,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1583,11 +1531,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"15123"	// Coffin Nail
@@ -1597,11 +1540,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1615,11 +1553,6 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
-				"value"	"0.0"
-			}
 		}
 	}
 	"15146"	// Corsair
@@ -1629,11 +1562,6 @@
 			"1"
 			{
 				"name"	"heal rate penalty"
-				"value"	"0.0"
-			}
-			"2"
-			{
-				"name"	"ubercharge rate penalty"
 				"value"	"0.0"
 			}
 		}
@@ -1708,7 +1636,7 @@
 			}
 		}
 	}
-	"59"	// The Dead Ringer
+	"59"	// Dead Ringer
 	{
 		"attributes"
 		{
@@ -1729,7 +1657,7 @@
 			}
 		}
 	}
-	"60"	// The Cloak and Dagger
+	"60"	// Cloak and Dagger
 	{
 		"attributes"
 		{
@@ -1776,7 +1704,7 @@
 			}
 		}
 	}
-	"947"	// The Quackenbirdt
+	"947"	// Quackenbirdt
 	{
 		"attributes"
 		{
@@ -1799,7 +1727,7 @@
 	}
 	
 	// Multi-Class - Secondary [Slot 1]
-	"1101"	// The B.A.S.E. Jumper
+	"1101"	// B.A.S.E. Jumper
 	{
 		"attributes"
 		{

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1293,6 +1293,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"211"	// Medi Gun (Renamed/Strange)
@@ -1303,6 +1308,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1315,6 +1325,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"411"	// Quick-Fix
@@ -1325,6 +1340,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1337,6 +1357,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"796"	// Silver Botkiller Medi Gun Mk.I
@@ -1347,6 +1372,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1359,6 +1389,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"885"	// Rust Botkiller Medi Gun Mk.I
@@ -1369,6 +1404,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1381,6 +1421,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"903"	// Carbonado Botkiller Medi Gun Mk.I
@@ -1391,6 +1436,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1403,6 +1453,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"961"	// Silver Botkiller Medi Gun Mk.II
@@ -1413,6 +1468,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1425,6 +1485,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"998"	// Vaccinator
@@ -1435,6 +1500,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1447,6 +1517,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"15010"	// Wrapped Reviver
@@ -1457,6 +1532,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1469,6 +1549,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"15039"	// Civil Servant
@@ -1479,6 +1564,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1491,6 +1581,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"15078"	// Wildwood
@@ -1501,6 +1596,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1513,6 +1613,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"15121"	// Dressed To Kill
@@ -1523,6 +1628,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1535,6 +1645,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"15123"	// Coffin Nail
@@ -1545,6 +1660,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}
@@ -1557,6 +1677,11 @@
 				"name"	"heal rate penalty"
 				"value"	"0.0"
 			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
+			}
 		}
 	}
 	"15146"	// Corsair
@@ -1567,6 +1692,11 @@
 			{
 				"name"	"heal rate penalty"
 				"value"	"0.0"
+			}
+			"2"
+			{
+				"name"	"ubercharge rate penalty"
+				"value"	"0.5"
 			}
 		}
 	}

--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1278,6 +1278,18 @@
 				"value"	"0.0"
 			}
 		}
+		"entprops"
+		{
+			"1"
+			{
+				"target"		"player"
+				"name"			"m_iAmmo"
+				"type"			"data"
+				"field_type"	"int"
+				"value"			"0"
+				"element"		"1"
+			}
+		}
 	}
 	
 	// Medic - Secondary [Slot 1]

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -89,6 +89,12 @@ enum
 	WINREASON_STOPWATCH_PLAYING_ROUNDS
 };
 
+enum EntPropTarget
+{
+	Target_Item,
+	Target_Player
+}
+
 enum PreferenceType
 {
 	Preference_DontBeActivator = (1 << 0), 

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -101,7 +101,7 @@ enum PreferenceType
 	Preference_HideChatTips = (1 << 1)
 }
 
-char g_PreferenceNames[][] =  {
+char g_PreferenceNames[][] = {
 	"Preference_DontBeActivator", 
 	"Preference_HideChatTips"
 };
@@ -132,7 +132,7 @@ ArrayList g_CurrentActivators;
 #include "deathrun/stocks.sp"
 #include "deathrun/timers.sp"
 
-public Plugin pluginInfo =  {
+public Plugin pluginInfo = {
 	name = PLUGIN_NAME, 
 	author = PLUGIN_AUTHOR, 
 	description = "Team Fortress 2 Deathrun", 

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -30,7 +30,7 @@
 
 #define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
-#define PLUGIN_VERSION		"1.5.1"
+#define PLUGIN_VERSION		"1.6.0"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
 #define PLUGIN_TAG		"[{primary}" ... PLUGIN_NAME ... "{default}]"

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -34,6 +34,7 @@ enum struct ItemEntPropConfig
 	PropType type;				/*< Property type */
 	PropFieldType fieldType;	/*< Property field type */
 	char value[256];			/*< Property value */
+	int element;				/*< Property element, if it is an array */
 	
 	void ReadConfig(KeyValues kv)
 	{
@@ -50,9 +51,9 @@ enum struct ItemEntPropConfig
 		
 		char type[16];
 		kv.GetString("type", type, sizeof(type));
-		if (StrEqual(type, "send"))
+		if (StrEqual(type, "send") || StrEqual(type, "netprop"))
 			this.type = Prop_Send;
-		else if (StrEqual(type, "data"))
+		else if (StrEqual(type, "data") || StrEqual(type, "datamap"))
 			this.type = Prop_Data;
 		else
 			LogError("Invalid prop type: %s", type);
@@ -71,6 +72,8 @@ enum struct ItemEntPropConfig
 			LogError("Invalid prop field type: %s", fieldType);
 		
 		kv.GetString("value", this.value, 256);
+		
+		this.element = kv.GetNum("element");
 	}
 }
 
@@ -272,21 +275,21 @@ void Config_Apply(int client)
 						{
 							case PropField_Integer:
 							{
-								SetEntProp(entity, entprop.type, entprop.name, StringToInt(entprop.value));
+								SetEntProp(entity, entprop.type, entprop.name, StringToInt(entprop.value), _, entprop.element);
 							}
 							case PropField_Float:
 							{
-								SetEntPropFloat(entity, entprop.type, entprop.name, StringToFloat(entprop.value));
+								SetEntPropFloat(entity, entprop.type, entprop.name, StringToFloat(entprop.value), entprop.element);
 							}
 							case PropField_Vector:
 							{
 								float vector[3];
 								StringToVector(entprop.value, vector);
-								SetEntPropVector(entity, entprop.type, entprop.name, vector);
+								SetEntPropVector(entity, entprop.type, entprop.name, vector, entprop.element);
 							}
 							case PropField_String:
 							{
-								SetEntPropString(entity, entprop.type, entprop.name, entprop.value);
+								SetEntPropString(entity, entprop.type, entprop.name, entprop.value, entprop.element);
 							}
 						}
 					}

--- a/addons/sourcemod/scripting/deathrun/config.sp
+++ b/addons/sourcemod/scripting/deathrun/config.sp
@@ -17,8 +17,8 @@
 
 enum struct ItemAttributeConfig
 {
-	char name[256];			/*< Attribute name */
-	float value;			/*< Attribute value */
+	char name[256];	/*< Attribute name */
+	float value;	/*< Attribute value */
 	
 	void ReadConfig(KeyValues kv)
 	{
@@ -29,6 +29,7 @@ enum struct ItemAttributeConfig
 
 enum struct ItemEntPropConfig
 {
+	EntPropTarget target;		/*< Property target */
 	char name[256];				/*< Property name */
 	PropType type;				/*< Property type */
 	PropFieldType fieldType;	/*< Property field type */
@@ -36,14 +37,25 @@ enum struct ItemEntPropConfig
 	
 	void ReadConfig(KeyValues kv)
 	{
+		char target[16];
+		kv.GetString("target", target, sizeof(target));
+		if (StrEqual(target, "item") || StrEqual(target, "weapon"))
+			this.target = Target_Item;
+		else if (StrEqual(target, "player") || StrEqual(target, "client"))
+			this.target = Target_Player;
+		else
+			LogError("Invalid prop target: %s", target);
+		
 		kv.GetString("name", this.name, 256);
 		
-		char type[256];
+		char type[16];
 		kv.GetString("type", type, sizeof(type));
 		if (StrEqual(type, "send"))
 			this.type = Prop_Send;
 		else if (StrEqual(type, "data"))
 			this.type = Prop_Data;
+		else
+			LogError("Invalid prop type: %s", type);
 		
 		char fieldType[256];
 		kv.GetString("field_type", fieldType, sizeof(fieldType));
@@ -55,6 +67,8 @@ enum struct ItemEntPropConfig
 			this.fieldType = PropField_Vector;
 		else if (StrEqual(fieldType, "string"))
 			this.fieldType = PropField_String;
+		else
+			LogError("Invalid prop field type: %s", fieldType);
 		
 		kv.GetString("value", this.value, 256);
 	}
@@ -242,7 +256,13 @@ void Config_Apply(int client)
 					ItemEntPropConfig entprop;
 					if (config.entprops.GetArray(i, entprop, sizeof(entprop)) > 0)
 					{
-						if (!HasEntProp(item, entprop.type, entprop.name))
+						int entity;
+						if (entprop.target == Target_Item)
+							entity = item;
+						else if (entprop.target == Target_Player)
+							entity = client;
+						
+						if (!HasEntProp(entity, entprop.type, entprop.name))
 						{
 							LogError("Invalid entity property: %s", entprop.name);
 							continue;
@@ -252,21 +272,21 @@ void Config_Apply(int client)
 						{
 							case PropField_Integer:
 							{
-								SetEntProp(item, entprop.type, entprop.name, StringToInt(entprop.value));
+								SetEntProp(entity, entprop.type, entprop.name, StringToInt(entprop.value));
 							}
 							case PropField_Float:
 							{
-								SetEntPropFloat(item, entprop.type, entprop.name, StringToFloat(entprop.value));
+								SetEntPropFloat(entity, entprop.type, entprop.name, StringToFloat(entprop.value));
 							}
 							case PropField_Vector:
 							{
 								float vector[3];
 								StringToVector(entprop.value, vector);
-								SetEntPropVector(item, entprop.type, entprop.name, vector);
+								SetEntPropVector(entity, entprop.type, entprop.name, vector);
 							}
 							case PropField_String:
 							{
-								SetEntPropString(item, entprop.type, entprop.name, entprop.value);
+								SetEntPropString(entity, entprop.type, entprop.name, entprop.value);
 							}
 						}
 					}

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -39,7 +39,7 @@ void ConVars_Init()
 	dr_activator_healthbar = CreateConVar("dr_activator_healthbar", "1", "If enabled, the activator health will be displayed on screen.");
 	dr_backstab_damage = CreateConVar("dr_backstab_damage", "750.0", "Damage dealt to the activator by backstabs. Set to 0 to let the game determine the damage.");
 	dr_speed_modifier[0] = CreateConVar("dr_speed_modifier", "0.0", "Maximum speed modifier for all classes, in HU/s.");
-	dr_speed_modifier[1] = CreateConVar("dr_speed_modifier_scout", "-80.0", "Maximum speed modifier for Scout, in HU/s.");
+	dr_speed_modifier[1] = CreateConVar("dr_speed_modifier_scout", "0.0", "Maximum speed modifier for Scout, in HU/s.");
 	dr_speed_modifier[2] = CreateConVar("dr_speed_modifier_sniper", "0.0", "Maximum speed modifier for Sniper, in HU/s.");
 	dr_speed_modifier[3] = CreateConVar("dr_speed_modifier_soldier", "0.0", "Maximum speed modifier for Soldier, in HU/s.");
 	dr_speed_modifier[4] = CreateConVar("dr_speed_modifier_demoman", "0.0", "Maximum speed modifier for Demoman, in HU/s.");

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -187,7 +187,7 @@ public void RequestFrame_VerifyTeam(int client)
 	
 	if (DRPlayer(client).IsActivator())
 	{
-		if (team == TFTeam_Runners) //Check if player is in the runner team, if so put them back to the activator team
+		if (team == TFTeam_Runners)	//Check if player is in the runner team, if so put them back to the activator team
 		{
 			TF2_ChangeClientTeam(client, TFTeam_Activators);
 			TF2_RespawnPlayer(client);
@@ -195,7 +195,7 @@ public void RequestFrame_VerifyTeam(int client)
 	}
 	else
 	{
-		if (team == TFTeam_Activators) //Check if player is in the activator team, if so put them back to the runner team
+		if (team == TFTeam_Activators)	//Check if player is in the activator team, if so put them back to the runner team
 		{
 			TF2_ChangeClientTeam(client, TFTeam_Runners);
 			TF2_RespawnPlayer(client);

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -100,8 +100,8 @@ public Action EventHook_PostInventoryApplication(Event event, const char[] name,
 	int client = GetClientOfUserId(userid);
 	
 	RequestFrame(Config_Apply, client);
-	
-	RequestFrame(RequestFrameCallback_VerifyTeam, userid);
+	RequestFrame(RequestFrame_VerifyTeam, client);
+	RequestFrame(RequestFrame_AddActivatorHealth, client);
 }
 
 public Action EventHook_TeamplayRoundStart(Event event, const char[] name, bool dontBroadcast)
@@ -179,29 +179,41 @@ public Action EventHook_TeamplayRoundWin(Event event, const char[] name, bool do
 	}
 }
 
-public void RequestFrameCallback_VerifyTeam(int userid)
+public void RequestFrame_VerifyTeam(int client)
 {
-	int client = GetClientOfUserId(userid);
-	if (IsValidClient(client) && IsClientInGame(client))
+	TFTeam team = TF2_GetClientTeam(client);
+	if (team <= TFTeam_Spectator)
+		return;
+	
+	if (DRPlayer(client).IsActivator())
 	{
-		TFTeam team = TF2_GetClientTeam(client);
-		if (team <= TFTeam_Spectator)return;
-		
-		if (DRPlayer(client).IsActivator())
+		if (team == TFTeam_Runners) //Check if player is in the runner team, if so put them back to the activator team
 		{
-			if (team == TFTeam_Runners)	//Check if player is in the runner team, if so put them back to the activator team
-			{
-				TF2_ChangeClientTeam(client, TFTeam_Activators);
-				TF2_RespawnPlayer(client);
-			}
+			TF2_ChangeClientTeam(client, TFTeam_Activators);
+			TF2_RespawnPlayer(client);
 		}
-		else
+	}
+	else
+	{
+		if (team == TFTeam_Activators) //Check if player is in the activator team, if so put them back to the runner team
 		{
-			if (team == TFTeam_Activators)	//Check if player is in the activator team, if so put them back to the runner team
-			{
-				TF2_ChangeClientTeam(client, TFTeam_Runners);
-				TF2_RespawnPlayer(client);
-			}
+			TF2_ChangeClientTeam(client, TFTeam_Runners);
+			TF2_RespawnPlayer(client);
+		}
+	}
+}
+
+public void RequestFrame_AddActivatorHealth(int client)
+{
+	//If the player respawns during a round, grant the activator some health back
+	if (GameRules_GetRoundState() == RoundState_Stalemate)
+	{
+		int healthToAdd = RoundToCeil(float(TF2_GetMaxHealth(client)) / float(g_CurrentActivators.Length));
+		for (int i = 0; i < g_CurrentActivators.Length; i++)
+		{
+			int activator = g_CurrentActivators.Get(i);
+			if (IsClientInGame(activator))
+				SetEntityHealth(activator, GetEntProp(activator, Prop_Data, "m_iHealth") + healthToAdd);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -205,8 +205,8 @@ public void RequestFrame_VerifyTeam(int client)
 
 public void RequestFrame_AddActivatorHealth(int client)
 {
-	//If the player respawns during a round, grant the activator some health back
-	if (GameRules_GetRoundState() == RoundState_Stalemate)
+	//If a runner respawns during the round, grant the activator some health back
+	if (!DRPlayer(client).IsActivator() && GameRules_GetRoundState() == RoundState_Stalemate)
 	{
 		int healthToAdd = RoundToCeil(float(TF2_GetMaxHealth(client)) / float(g_CurrentActivators.Length));
 		for (int i = 0; i < g_CurrentActivators.Length; i++)

--- a/addons/sourcemod/scripting/deathrun/events.sp
+++ b/addons/sourcemod/scripting/deathrun/events.sp
@@ -99,7 +99,7 @@ public Action EventHook_PostInventoryApplication(Event event, const char[] name,
 	int userid = event.GetInt("userid");
 	int client = GetClientOfUserId(userid);
 	
-	Config_Apply(client);
+	RequestFrame(Config_Apply, client);
 	
 	RequestFrame(RequestFrameCallback_VerifyTeam, userid);
 }


### PR DESCRIPTION
* Advanced entprop configuration support
  * Added a way to target the client instead of just the item (`target` config key)
  * Added support for setting specific array elements (`element` config key)
* Significantly overhauled the default configuration
* Grant the activator some health if a runner respawns during an active round