### PR TITLE
Fix incorrect index from Coffin Nail Medigun

### DIFF
--- a/addons/sourcemod/configs/deathrun/items.cfg
+++ b/addons/sourcemod/configs/deathrun/items.cfg
@@ -1550,7 +1550,7 @@
 			}
 		}
 	}
-	"15123"	// Coffin Nail
+	"15120"	// Coffin Nail
 	{
 		"attributes"
 		{


### PR DESCRIPTION
Alliedmods wiki is a lie.

`15123` is Coffin Nail Minigun, while `15120` is actual Coffin Nail Medigun