### PR TITLE
Add health scaling convar that is disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Any item definition indexes specified in a map-specific item configuration will 
   chat tips.
 - `dr_runner_glow ( def. "0" )` - If enabled, runners will have a glowing outline.
 - `dr_activator_count ( def. "1" )` - Amount of activators chosen at the start of a round.
+- `dr_activator_scale_health ( def. "0" )` - Whether to scale activator's health with the set modifier or not. Set to 1 in order to scale, and 0 to keep class default health.
 - `dr_activator_health_modifier ( def. "1.0" )` - Modifier of the health the activator receives from runners.
 - `dr_activator_healthbar ( def. "1" )` - If enabled, the activator health will be displayed on screen.
 - `dr_backstab_damage ( def. "750.0" )` - Damage dealt to the activator by backstabs. Set to 0 to let the game determine the damage.

--- a/addons/sourcemod/scripting/deathrun.sp
+++ b/addons/sourcemod/scripting/deathrun.sp
@@ -29,7 +29,7 @@
 
 #define PLUGIN_NAME			"Deathrun Neu"
 #define PLUGIN_AUTHOR		"Mikusch"
-#define PLUGIN_VERSION		"1.7.0"
+#define PLUGIN_VERSION		"1.7.1"
 #define PLUGIN_URL			"https://github.com/Mikusch/deathrun"
 
 #define PLUGIN_TAG		"[{primary}" ... PLUGIN_NAME ... "{default}]"
@@ -109,6 +109,7 @@ ConVar dr_queue_points;
 ConVar dr_chattips_interval;
 ConVar dr_runner_glow;
 ConVar dr_activator_count;
+ConVar dr_activator_scale_health;
 ConVar dr_activator_health_modifier;
 ConVar dr_activator_healthbar;
 ConVar dr_backstab_damage;

--- a/addons/sourcemod/scripting/deathrun/convars.sp
+++ b/addons/sourcemod/scripting/deathrun/convars.sp
@@ -37,6 +37,7 @@ void ConVars_Init()
 	dr_runner_glow = CreateConVar("dr_runner_glow", "0", "If enabled, runners will have a glowing outline.");
 	dr_runner_glow.AddChangeHook(OnConVarChanged_RunnerGlow);
 	dr_activator_count = CreateConVar("dr_activator_count", "1", "Amount of activators chosen at the start of a round.", _, true, 1.0, true, float(MaxClients - 1));
+	dr_activator_scale_health = CreateConVar("dr_activator_scale_health", "0", "Whether to scale the health of the activator or not.", _);
 	dr_activator_health_modifier = CreateConVar("dr_activator_health_modifier", "1.0", "Modifier of the health the activator receives from runners.", _, true, 0.0);
 	dr_activator_healthbar = CreateConVar("dr_activator_healthbar", "1", "If enabled, the activator health will be displayed on screen.");
 	dr_activator_healthbar.AddChangeHook(OnConVarChanged_ActivatorHealthBar);

--- a/addons/sourcemod/scripting/deathrun/dhooks.sp
+++ b/addons/sourcemod/scripting/deathrun/dhooks.sp
@@ -111,7 +111,7 @@ public MRESReturn DHookCallback_GetMaxHealthForBuffing_Post(int client, DHookRet
 		
 		for (int i = 1; i <= MaxClients; i++)
 		{
-			if (client != i && IsValidClient(i) && IsPlayerAlive(i) && !DRPlayer(i).IsActivator())
+			if (client != i && IsValidClient(i) && IsPlayerAlive(i) && !DRPlayer(i).IsActivator() && dr_activator_scale_health.IntValue == 1)
 				maxhealth += RoundFloat(TF2_GetMaxHealth(i) * dr_activator_health_modifier.FloatValue);
 		}
 		


### PR DESCRIPTION
This pull request addresses issue #23, where it was suggested that there should be an option to toggle health scaling with a ConVar, and that it should be disabled by default due to mapmakers handling health scaling on their own. 